### PR TITLE
Mutation pools updates

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/api/CropsNHMutationPools.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/api/CropsNHMutationPools.java
@@ -58,6 +58,7 @@ public abstract class CropsNHMutationPools {
     public final static String aPine = "pine";
     public final static String aPointed = "pointed";
     public final static String aPoison = "poison";
+    public final static String aPrimordial = "primordial";
     public final static String aPurple = "purple";
     public final static String aRadioactive = "radioactive";
     public final static String aRed = "red";

--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/MutationLoader.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/MutationLoader.java
@@ -232,6 +232,7 @@ import static com.gtnewhorizon.cropsnh.api.CropsNHMutationPools.aOreBerry;
 import static com.gtnewhorizon.cropsnh.api.CropsNHMutationPools.aPine;
 import static com.gtnewhorizon.cropsnh.api.CropsNHMutationPools.aPointed;
 import static com.gtnewhorizon.cropsnh.api.CropsNHMutationPools.aPoison;
+import static com.gtnewhorizon.cropsnh.api.CropsNHMutationPools.aPrimordial;
 import static com.gtnewhorizon.cropsnh.api.CropsNHMutationPools.aPurple;
 import static com.gtnewhorizon.cropsnh.api.CropsNHMutationPools.aRadioactive;
 import static com.gtnewhorizon.cropsnh.api.CropsNHMutationPools.aRed;
@@ -534,9 +535,10 @@ public class MutationLoader {
         }
         if (ModUtils.Thaumcraft.isModLoaded() && ModUtils.ThaumicTinkerer.isModLoaded()) {
             new CropMutation(MagicalNightshade, PrimordialBerry, ManaBean, Cinderpearl, Shimmerleaf)
-                .addToMutationPools(aBerry, aMagic)
+                .addToMutationPools(aBerry, aMagic, aPrimordial)
                 .machineOnly()
                 .register();
+            MutationRegistry.instance.register(PrimordialBerry, aPrimordial);
         }
         new CropMutation(Micadia, Tine, Bauxia)
             .addToMutationPools(aMetal, aPine, aBush)


### PR DESCRIPTION
- Gets rid of a lot of single-members mutation pools.
- Removes mutation pools from gaia wart since it's not supposed to be breedable without it's special mechanic
  - Was planning on having it as a fallback but ehhh, that thing needs snow under to grow so ya can't grow it anyway if you don't got snow.
- Adds new pools to crops here and there to match.