### PR TITLE
Fix duplicate mutation for Allium and Belladonna

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/MutationLoader.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/MutationLoader.java
@@ -923,7 +923,7 @@ public class MutationLoader {
 
         // region witchery
         if (ModUtils.Witchery.isModLoaded()) {
-            new CropMutation(Belladonna, PurpleTulip, PinkTulip)
+            new CropMutation(Belladonna, PurpleTulip, Huckleberry)
                 .addToMutationPools(aPurple, aFlower, aToxic, aIngredient)
                 .register();
             if (ModUtils.BiomesOPlenty.isModLoaded()) {


### PR DESCRIPTION
Fixes a recipe conflict between Allium and Belladonna in the seed generator.
- This was done by altering the mutation parents of belladonna so that it requires purple tulip and huckleberry instead of purple tulip and pink tulip.

Crops like iridine/osmium and ferrofern/tufflily also have duplicate parent lists, but this isn't as much of an issue thanks to the additional factor of growth requirements, still separating them.

Tearstalks and evil ore were also brought up in previous conversations, but this is also fine since the breeder will always prioritize mutations with the highest amount of parents. So it's just a question of putting in the seeds in the right order.
- It would probably be advisable to add a note in the quest book about this.
- The crop sticks deal with this situation a bit differently, finding all viable mutations, and it picks one at random, without any prioritization.

resolves #23 