### PR TITLE
Prevent weed and migrator crops from showing up in NEI

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/compatibility/NEI/NEICropsNHCropHandler.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/compatibility/NEI/NEICropsNHCropHandler.java
@@ -228,6 +228,7 @@ public class NEICropsNHCropHandler extends CropsNHNEIHandler {
 
         // find crops it's a soil or under-block for.
         outer: for (ICropCard cropCard : CropRegistry.instance.getAllInRegistrationOrder()) {
+            if (cropCard.hideFromNEI()) continue;
             if (cropCard.getSoilTypes()
                 .isRegistered(block, CropsNHUtils.getItemMeta(item))) {
                 arecipes.add(new CachedCropRecipe(null, cropCard));


### PR DESCRIPTION
This PR prevents weeds and migratory crops from showing up in nei when inspecting the usages of a block that is a member of any cropsNH soil list

Resolves #90 