### PR TITLE
Allow weed-ex to prevent disease transmission to healthy crops.

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/items/tools/ItemPlantCure.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/items/tools/ItemPlantCure.java
@@ -32,6 +32,8 @@ public class ItemPlantCure extends Item implements ICropRightClickHandler {
         if (world.isRemote) return true;
         if (te.cureDisease()) {
             // add a bit of fertilizer so it doesn't fall sick again for a bit.
+            // for curing large fields, of sickness, the intended solution is to use a crop manager to apply weed-ex
+            // over the area and then use plant cure to save all the crops.
             te.addFertilizer(25, 25, 25, false);
             if (!player.capabilities.isCreativeMode) {
                 heldItem.damageItem(1, player);

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
@@ -1073,11 +1073,20 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
     @Override
     public void transferDisease() {
         if (!this.hasCrop() || this.isSick || this.hasWeed()) return;
-        if (!this.passesResistanceCheck()) {
-            this.isSick = true;
-            this.isDirty = true;
-            this.markDirty();
+        // if we have weed-ex remaining, stop the weeding.
+        // migrator crops can't fall sick
+        if (this.seed.getCrop() instanceof CropMigrator) return;
+        // resistance can prevent weed-spread.
+        if (this.passesResistanceCheck()) return;
+        // weed-ex prevents crops that falling sick
+        if (this.weedEXStorage > 0) {
+            // allow over-consumption
+            this.weedEXStorage = Math.max(this.weedEXStorage - 2, 0);
+            return;
         }
+        this.isSick = true;
+        this.isDirty = true;
+        this.markDirty();
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
@@ -843,6 +843,7 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
         // if we have weed-ex remaining, stop the weeding.
         if (this.weedEXStorage > 0) {
             this.weedEXStorage = Math.max(this.weedEXStorage - 5, 0);
+            this.markDirty();
             return;
         }
         // else weed this thing
@@ -1082,6 +1083,7 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
         if (this.weedEXStorage > 0) {
             // allow over-consumption
             this.weedEXStorage = Math.max(this.weedEXStorage - 2, 0);
+            this.markDirty();
             return;
         }
         this.isSick = true;


### PR DESCRIPTION
This PR adds missing functionality that made curing large fields of sick crops near impossible at lower resistance values. Weed-EX was supposed to prevent crops from catching a disease from a neighbouring crop, but ehh, I forgot to add that.

Resolves #89