### PR TITLE
Fix structure localisations in the projector ui

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/api/CropsNHStructureChannels.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/api/CropsNHStructureChannels.java
@@ -34,6 +34,10 @@ public enum CropsNHStructureChannels implements IStructureChannels {
         return StatCollector.translateToLocal(this.mTooltip);
     }
 
+    public String getUnlocalizedTooltip() {
+        return this.mTooltip;
+    }
+
     @Override
     public void registerAsIndicator(ItemStack indicator, int channelValue) {
         StructureLibAPI.registerChannelItem(get(), Mods.ModIDs.CROPS_NH, channelValue, indicator);

--- a/src/main/java/com/gtnewhorizon/cropsnh/compatibility/StructureLib/StructureLibCompatHandler.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/compatibility/StructureLib/StructureLibCompatHandler.java
@@ -12,7 +12,11 @@ public class StructureLibCompatHandler {
         StructureLibAPI.registerChannelDescription(
             CropsNHStructureChannels.IFUpgrades.get(),
             Reference.MOD_ID,
-            CropsNHStructureChannels.IFUpgrades.get());
+            CropsNHStructureChannels.IFUpgrades.getUnlocalizedTooltip());
+        StructureLibAPI.registerChannelDescription(
+            CropsNHStructureChannels.IFTier.get(),
+            Reference.MOD_ID,
+            CropsNHStructureChannels.IFTier.getUnlocalizedTooltip());
     }
 
 }


### PR DESCRIPTION
This PR fixes an issue where the IF_tier structure channel didn't have its description set, and both used the wrong localization value when registering the description.