### PR TITLE
Add better default tooltip and visuals handling for quest book.

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/items/ItemGenericSeed.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/items/ItemGenericSeed.java
@@ -215,7 +215,13 @@ public class ItemGenericSeed extends ItemCropsNH {
     public int getColorFromItemStack(ItemStack stack, int pass) {
         // load the crop card
         ICropCard cropCard = CropRegistry.instance.get(stack);
-        if (cropCard == null) return pass == 0 ? 0xB7BB3F : 0x00E210;
+        if (cropCard == null) {
+            if (stack != null && stack.hasTagCompound()
+                && stack.getTagCompound()
+                    .hasKey("crop", Constants.NBT.TAG_STRING))
+                return pass == 0 ? 0x000000 : 0xffffff;
+            return pass == 0 ? 0xB7BB3F : 0x00E210;
+        }
         return pass == 0 ? cropCard.getPrimarySeedColor() : cropCard.getSecondarySeedColor();
     }
 

--- a/src/main/java/com/gtnewhorizon/cropsnh/items/ItemGenericSeed.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/items/ItemGenericSeed.java
@@ -105,16 +105,17 @@ public class ItemGenericSeed extends ItemCropsNH {
     }
 
     @Override
-    public void addInformation(ItemStack stack, EntityPlayer player, List toolTip, boolean showAdvancedItemTooltips) {
+    public void addInformation(ItemStack stack, EntityPlayer player, List<String> toolTip,
+        boolean showAdvancedItemTooltips) {
         if (stack == null || !(stack.getItem() instanceof ItemGenericSeed) || !stack.hasTagCompound()) {
             return;
         }
         ICropCard crop = CropRegistry.instance.get(stack);
-        if (crop == null) return;
+        // if (crop == null) return;
 
         ISeedStats stats = SeedStats.readFromNBT(stack.getTagCompound());
         if (stats.isAnalyzed()) {
-            if (crop.getFlavourText() != null) {
+            if (crop != null && crop.getFlavourText() != null) {
                 toolTip.add(StatCollector.translateToLocal(crop.getFlavourText()));
             }
 
@@ -140,32 +141,36 @@ public class ItemGenericSeed extends ItemCropsNH {
                     stats.getResistance(),
                     EnumChatFormatting.RESET));
 
-            if (crop.getCrossingThreshold() < 0.0f) {
-                toolTip.add(
-                    StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.mustUseSeedSynthesizerToReplicate"));
-            }
-
-            Collection<ICropMutation> mutations = MutationRegistry.instance.getDeterministicMutationsForCrop(crop);
-            if (mutations != null && mutations.stream()
-                .allMatch(
-                    m -> m.getRequirements()
-                        .stream()
-                        .anyMatch(r -> r instanceof MachineOnlyBreedingRequirement))) {
-                toolTip.add(StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.mustUseBreederMachine"));
-            }
-
-            Iterable<IGrowthRequirement> reqs = crop.getGrowthRequirements();
-            if (reqs != null) {
-                for (IGrowthRequirement req : reqs) {
-                    toolTip.add(req.getDescription());
+            if (crop != null) {
+                if (crop.getCrossingThreshold() < 0.0f) {
+                    toolTip.add(
+                        StatCollector
+                            .translateToLocal(Reference.MOD_ID + "_tooltip.mustUseSeedSynthesizerToReplicate"));
                 }
-            }
-            int minSeedBedTier = crop.getMinSeedBedTier();
-            if (minSeedBedTier >= 0) {
-                toolTip.add(
-                    StatCollector.translateToLocalFormatted(
-                        Reference.MOD_ID + "_tooltip.min_seed_bed_tier",
-                        GTValues.TIER_COLORS[minSeedBedTier] + GTValues.VN[minSeedBedTier] + EnumChatFormatting.RESET));
+
+                Collection<ICropMutation> mutations = MutationRegistry.instance.getDeterministicMutationsForCrop(crop);
+                if (mutations != null && mutations.stream()
+                    .allMatch(
+                        m -> m.getRequirements()
+                            .stream()
+                            .anyMatch(r -> r instanceof MachineOnlyBreedingRequirement))) {
+                    toolTip.add(StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.mustUseBreederMachine"));
+                }
+
+                Iterable<IGrowthRequirement> reqs = crop.getGrowthRequirements();
+                if (reqs != null) {
+                    for (IGrowthRequirement req : reqs) {
+                        toolTip.add(req.getDescription());
+                    }
+                }
+                int minSeedBedTier = crop.getMinSeedBedTier();
+                if (minSeedBedTier >= 0) {
+                    toolTip.add(
+                        StatCollector.translateToLocalFormatted(
+                            Reference.MOD_ID + "_tooltip.min_seed_bed_tier",
+                            GTValues.TIER_COLORS[minSeedBedTier] + GTValues.VN[minSeedBedTier]
+                                + EnumChatFormatting.RESET));
+                }
             }
         } else {
             toolTip.add(" " + StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.unidentified"));
@@ -197,7 +202,7 @@ public class ItemGenericSeed extends ItemCropsNH {
     public int getColorFromItemStack(ItemStack stack, int pass) {
         // load the crop card
         ICropCard cropCard = CropRegistry.instance.get(stack);
-        if (cropCard == null) return pass == 0 ? 0x000000 : 0xffffff;
+        if (cropCard == null) return pass == 0 ? 0xB7BB3F : 0x00E210;
         return pass == 0 ? cropCard.getPrimarySeedColor() : cropCard.getSecondarySeedColor();
     }
 

--- a/src/main/java/com/gtnewhorizon/cropsnh/items/ItemGenericSeed.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/items/ItemGenericSeed.java
@@ -13,6 +13,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
+import net.minecraftforge.common.util.Constants;
 
 import com.gtnewhorizon.cropsnh.api.ICropCard;
 import com.gtnewhorizon.cropsnh.api.ICropMutation;
@@ -68,7 +69,19 @@ public class ItemGenericSeed extends ItemCropsNH {
     public String getUnlocalizedName(ItemStack stack) {
         // load the crop card
         ICropCard cropCard = CropRegistry.instance.get(stack);
-        if (cropCard == null) return Names.L10N.invalidSeed;
+        if (cropCard == null) {
+            if (stack != null && stack.hasTagCompound()) {
+                NBTTagCompound tag = stack.getTagCompound();
+                if (tag.hasKey(Names.NBT.growth, Constants.NBT.TAG_BYTE)
+                    && tag.hasKey(Names.NBT.gain, Constants.NBT.TAG_BYTE)
+                    && tag.hasKey(Names.NBT.resistance, Constants.NBT.TAG_BYTE)
+                    && tag.hasKey(Names.NBT.analyzed, Constants.NBT.TAG_BYTE)
+                    && tag.getBoolean(Names.NBT.analyzed)) {
+                    return Names.L10N.anyCropsNHSeed;
+                }
+            }
+            return Names.L10N.invalidSeed;
+        }
 
         // if the seed hasn't been analyzed don't name the seeds.
         ISeedStats stats = SeedStats.getStatsFromStack(stack);

--- a/src/main/java/com/gtnewhorizon/cropsnh/reference/Names.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/reference/Names.java
@@ -9,6 +9,7 @@ public final class Names {
         private static final String growthReqPrefix = modPrefix + "growthReq.";
         public static final String unknownSeed = genericSeedPrefix + "unknown";
         public static final String invalidSeed = genericSeedPrefix + "invalid";
+        public static final String anyCropsNHSeed = genericSeedPrefix + "any";
         public static final String genericSeedFormat = genericSeedPrefix + "format";
         public static final String blockUnderReqFormat = growthReqPrefix + "format";
     }

--- a/src/main/resources/assets/cropsnh/lang/en_US.lang
+++ b/src/main/resources/assets/cropsnh/lang/en_US.lang
@@ -527,6 +527,7 @@ nei.options.tools.dump.cropsnh.weedEXFluids=WeedEX
 # Generic Seeds
 cropsnh_genericSeeds.unknown=Unknown
 cropsnh_genericSeeds.invalid=Invalid
+cropsnh_genericSeeds.any=Any Crops NH
 cropsnh_genericSeeds.format=%1$s Seeds
 
 # Crop Names


### PR DESCRIPTION
This PR changes the tooltips to show stats for analyzed invalid seeds, so they don't look too out of place in the quest book. 

Here is an example of an invalid seed that is scanned:
<img width="580" height="210" alt="image" src="https://github.com/user-attachments/assets/ce6e951b-be2e-4784-82da-ae6085e1578e" />
<img width="271" height="280" alt="image" src="https://github.com/user-attachments/assets/9f7720e3-20dd-4f4b-8f31-9bc3ee4d88df" />


Here is an example of an invalid seed that isn't scanned
<img width="457" height="144" alt="image" src="https://github.com/user-attachments/assets/2ec98b6e-680f-4ac3-8a49-eb7e399b0ff9" />
<img width="227" height="189" alt="image" src="https://github.com/user-attachments/assets/4774b899-e3dd-4d34-b6cd-005e51bb4300" />

Crops with invalid crop IDs are still labelled with the broken colouring for a better dev/testing experience
<img width="458" height="143" alt="image" src="https://github.com/user-attachments/assets/d9bfb482-a193-46f4-966e-595eb9a7732d" />
<img width="417" height="321" alt="image" src="https://github.com/user-attachments/assets/894419b1-eead-4258-84f4-95b895bc0e09" />
