### PR TITLE
Allow crops that can see the sky to get watered by rain

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
@@ -1195,6 +1195,12 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
         // let the can grow logic run on the client so that it's able to tell the player why a crop isn't growing.
         boolean canGrow = this.canGrow();
         if (worldObj.isRemote) return;
+        // add water to crops when it's raining and the crop stick is not in a snow less biome
+        // this technically ignores glass, but I'll let that slide.
+        if (this.worldObj.canLightningStrikeAt(this.xCoord, this.yCoord, this.zCoord)) {
+            // 101 because the first will be consumed and then it's not the full bonus.
+            this.addWater(11, 100, 101, false);
+        }
         if (this.hasCrop()) {
             // abort early if the migrator crop is present (it should only be harvested by the player)
             if (this.seed.getCrop() instanceof CropMigrator) {


### PR DESCRIPTION
Technically, glass doesn't prevent this from happening, but it does properly handle rainless biomes and doesn't water crops when the sticks are so high that rain is replaced by snow.

Water is added at a speed of 10 per growth ticks (256 ticks). The value added is 11 because the consumption code down the line subtracts 1.