### PR TITLE
Fix thornvine typo

### DIFF
--- a/src/main/resources/assets/cropsnh/lang/en_US.lang
+++ b/src/main/resources/assets/cropsnh/lang/en_US.lang
@@ -662,7 +662,7 @@ cropsnh_crops.blueGlowshroom=Blue Glowshroom
 cropsnh_crops.greenGlowshroom=Green Glowshroom
 cropsnh_crops.purpleGlowshroom=Purple Glowshroom
 # Natura Nether Crop Names
-cropsnh_crops.thornvine=Thronvine
+cropsnh_crops.thornvine=Thornvine
 # Ore Berries
 cropsnh_crops.aluminiumOreBerry=Aluminium Oreberry
 cropsnh_crops.arditeOreBerry=Ardite Oreberry


### PR DESCRIPTION
Fixes a typo in the default localization for thornvine, used to be th`ro`nvine 