### PR TITLE
Replace Titania with Rubyne for the Platina mutation

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/MutationLoader.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/MutationLoader.java
@@ -556,7 +556,7 @@ public class MutationLoader {
             .addToMutationPools(aWhite, aStem)
             .register();
         // TODO: ADD CHROME CROP AND REPLACE TITANIA WITH NEW CROP IN PLATINA MUTATION
-        new CropMutation(Platina, Diareed, Titania)
+        new CropMutation(Platina, Diareed, Rubyne)
             .machineOnly()
             .register();
         new CropMutation(Plumbilia, Coppon, Withereed)


### PR DESCRIPTION
Rubine is much closer to a chrome crop than titania, and that just more closely matches the old todo I left behind.

This also changes the crop's tier gate from EV (due to titania) to HV (due to breeder/IF requirements). This is fine since HV should have been its tier gate, IDK why I put Titania as one of its parents.