### PR TITLE
Backhand integration for watering can interactions.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,6 +9,10 @@ dependencies {
     devOnlyNonPublishable("com.github.GTNewHorizons:ForestryMC:4.11.12:dev") { transitive = false }
     devOnlyNonPublishable("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
 
+    compileOnly('com.github.GTNewHorizons:Backhand:1.8.8:dev') { transitive = false }
+    compileOnly(deobfCurse("extra-utilities-225561:2264384")) { transitive = false }
+
+
     // // debugging tools
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:NewHorizonsCoreMod:2.8.195:dev")
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:ServerUtilities:2.2.20:dev") { transitive = false }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -8,9 +8,7 @@ dependencies {
     devOnlyNonPublishable("com.github.GTNewHorizons:waila:1.19.22:dev") { transitive = false }
     devOnlyNonPublishable("com.github.GTNewHorizons:ForestryMC:4.11.12:dev") { transitive = false }
     devOnlyNonPublishable("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
-
-    compileOnly('com.github.GTNewHorizons:Backhand:1.8.8:dev') { transitive = false }
-    compileOnly(deobfCurse("extra-utilities-225561:2264384")) { transitive = false }
+    devOnlyNonPublishable('com.github.GTNewHorizons:Backhand:1.8.8:dev') { transitive = false }
 
 
     // // debugging tools
@@ -72,7 +70,6 @@ dependencies {
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:EnderIO:2.10.22:dev') { transitive = false }
     // // watering can interactions
     // runtimeOnlyNonPublishable(rfg.deobf("curse.maven:extra-utilities-225561:2264383")) { transitive = false }
-    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:Backhand:1.8.9:dev') { transitive = false }
 }
 
 project.getConfigurations()

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -68,6 +68,7 @@ dependencies {
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:EnderIO:2.10.22:dev') { transitive = false }
     // // watering can interactions
     // runtimeOnlyNonPublishable(rfg.deobf("curse.maven:extra-utilities-225561:2264383")) { transitive = false }
+    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:Backhand:1.8.9:dev') { transitive = false }
 }
 
 project.getConfigurations()

--- a/src/main/java/com/gtnewhorizon/cropsnh/blocks/BlockCropSticks.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/blocks/BlockCropSticks.java
@@ -6,6 +6,7 @@ import net.minecraft.client.particle.EffectRenderer;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -29,6 +30,8 @@ import com.gtnewhorizon.cropsnh.renderers.blocks.RenderBlockBase;
 import com.gtnewhorizon.cropsnh.renderers.blocks.RenderCrop;
 import com.gtnewhorizon.cropsnh.tileentity.TileEntityCropSticks;
 import com.gtnewhorizon.cropsnh.tileentity.TileEntityCropsNH;
+import com.gtnewhorizon.cropsnh.utility.CropsNHUtils;
+import com.gtnewhorizon.cropsnh.utility.MetaSet;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -38,6 +41,7 @@ import cpw.mods.fml.relauncher.SideOnly;
  */
 public class BlockCropSticks extends BlockContainerCropsNH {
 
+    public static final MetaSet<Item> BLOCK_INTERACTION_WITH = new MetaSet<>();
     // 2 pixels all sides
     private static final float COLLISION_BOX_XZ_SHRINK = 0.125F;
     // 3 pixels on top side
@@ -79,11 +83,15 @@ public class BlockCropSticks extends BlockContainerCropsNH {
     @Override
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float fX, float fY,
         float fZ) {
+        // check if the item is blocked form interacting with crops directly
+        final ItemStack heldItem = player.getCurrentEquippedItem();
+        if (heldItem != null && heldItem.getItem() != null && BLOCK_INTERACTION_WITH.contains(heldItem.getItem(), CropsNHUtils.getItemMeta(heldItem))) {
+            return false;
+        }
 
         // else ensure that we have a crop tile
         final TileEntity te = world.getTileEntity(x, y, z);
         if (!(te instanceof final ICropStickTile crop)) return true;
-        final ItemStack heldItem = player.getCurrentEquippedItem();
 
         // if it can interact with crops deffer to that tool's logic.
         if (heldItem != null && heldItem.getItem() instanceof ICropRightClickHandler) {

--- a/src/main/java/com/gtnewhorizon/cropsnh/compatibility/backhand/BackhandCompat.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/compatibility/backhand/BackhandCompat.java
@@ -1,0 +1,38 @@
+package com.gtnewhorizon.cropsnh.compatibility.backhand;
+
+import static xonin.backhand.api.core.EnumHand.MAIN_HAND;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+
+import com.gtnewhorizon.cropsnh.blocks.BlockCropSticks;
+import com.gtnewhorizon.cropsnh.utility.ModUtils;
+import com.gtnewhorizon.gtnhlib.eventbus.EventBusSubscriber;
+import com.rwtema.extrautils.item.ItemWateringCan;
+
+import cpw.mods.fml.common.eventhandler.EventPriority;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import xonin.backhand.api.core.BackhandUtils;
+
+@EventBusSubscriber
+public class BackhandCompat {
+
+    @EventBusSubscriber.Condition
+    public static boolean register() {
+        return ModUtils.Backhand.isModLoaded() && ModUtils.ExtraUtilities.isModLoaded();
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public static void onPlayerInteract(PlayerInteractEvent event) {
+        if (event.world == null || event.action != PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK
+            || !BackhandUtils.isUsingOffhand(event.entityPlayer)) {
+            return;
+        }
+
+        ItemStack mainHand = MAIN_HAND.getItem(event.entityPlayer);
+        if (mainHand == null || !(mainHand.getItem() instanceof ItemWateringCan)) return;
+        if (event.world.getBlock(event.x, event.y, event.z) instanceof BlockCropSticks) {
+            event.setCanceled(true);
+        }
+    }
+}

--- a/src/main/java/com/gtnewhorizon/cropsnh/compatibility/backhand/BackhandCompat.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/compatibility/backhand/BackhandCompat.java
@@ -6,9 +6,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 
 import com.gtnewhorizon.cropsnh.blocks.BlockCropSticks;
+import com.gtnewhorizon.cropsnh.utility.CropsNHUtils;
 import com.gtnewhorizon.cropsnh.utility.ModUtils;
 import com.gtnewhorizon.gtnhlib.eventbus.EventBusSubscriber;
-import com.rwtema.extrautils.item.ItemWateringCan;
 
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
@@ -19,7 +19,7 @@ public class BackhandCompat {
 
     @EventBusSubscriber.Condition
     public static boolean register() {
-        return ModUtils.Backhand.isModLoaded() && ModUtils.ExtraUtilities.isModLoaded();
+        return ModUtils.Backhand.isModLoaded();
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
@@ -29,9 +29,14 @@ public class BackhandCompat {
             return;
         }
 
-        ItemStack mainHand = MAIN_HAND.getItem(event.entityPlayer);
-        if (mainHand == null || !(mainHand.getItem() instanceof ItemWateringCan)) return;
-        if (event.world.getBlock(event.x, event.y, event.z) instanceof BlockCropSticks) {
+        ItemStack mainHandStack = MAIN_HAND.getItem(event.entityPlayer);
+        if (mainHandStack == null || CropsNHUtils.isStackInvalid(mainHandStack)) return;
+
+        // check crop sticks
+        if (BlockCropSticks.BLOCK_INTERACTION_WITH
+            .contains(mainHandStack.getItem(), CropsNHUtils.getItemMeta(mainHandStack))
+            // do world check after since it's more computationally expansive
+            && event.world.getBlock(event.x, event.y, event.z) instanceof BlockCropSticks) {
             event.setCanceled(true);
         }
     }

--- a/src/main/java/com/gtnewhorizon/cropsnh/compatibility/extrautils/ExUWateringCanHandler.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/compatibility/extrautils/ExUWateringCanHandler.java
@@ -8,11 +8,10 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
-import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.entity.player.PlayerUseItemEvent;
 
 import com.gtnewhorizon.cropsnh.api.ICropStickTile;
-import com.gtnewhorizon.cropsnh.init.CropsNHBlocks;
+import com.gtnewhorizon.cropsnh.blocks.BlockCropSticks;
 import com.gtnewhorizon.cropsnh.utility.CropsNHUtils;
 import com.gtnewhorizon.cropsnh.utility.ModUtils;
 import com.gtnewhorizon.cropsnh.utility.XSTR;
@@ -33,16 +32,10 @@ public class ExUWateringCanHandler {
         if (EXTRA_UTILS_WATERING_CAN == null) {
             throw new LoaderException("Unable to find ExU watering can while ExU is installed!");
         }
-    }
-
-    // cancel the event so the watering animation plays
-    @SubscribeEvent
-    public void wateringCanHook(PlayerInteractEvent event) {
-        if (event.action != PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK) return;
-        ItemStack heldItem = event.entityPlayer.getHeldItem();
-        if (heldItem == null || heldItem.getItem() != EXTRA_UTILS_WATERING_CAN) return;
-        if (event.world.getBlock(event.x, event.y, event.z) != CropsNHBlocks.blockCropSticks) return;
-        event.setCanceled(true);
+        // reg (filled)
+        BlockCropSticks.BLOCK_INTERACTION_WITH.add(EXTRA_UTILS_WATERING_CAN, 0);
+        // reinforced
+        BlockCropSticks.BLOCK_INTERACTION_WITH.add(EXTRA_UTILS_WATERING_CAN, 3);
     }
 
     @SubscribeEvent
@@ -68,6 +61,10 @@ public class ExUWateringCanHandler {
     }
 
     // taken from the item class since it's usually a protected method
+    // the one from the Minecraft class results in slight inaccuracies so O figured it used the item one
+    // plus the Minecraft class version doesn't feel like it would work well with multiplayer since it's updated in
+    // render code. I could probably use a mixin as an access transformer, but this was faster and this is only a
+    // temporary measure until UiE get off the ground.
     private MovingObjectPosition getMovingObjectPositionFromPlayer(World worldIn, EntityPlayer player,
         boolean useLiquids) {
         float f = 1.0F;

--- a/src/main/java/com/gtnewhorizon/cropsnh/utility/ModUtils.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/utility/ModUtils.java
@@ -16,6 +16,7 @@ public enum ModUtils implements IMod {
 
     Angelica(ModIDs.Angelica),
     Avaritia(ModIDs.Avaritia),
+    Backhand(ModIDs.Backhand),
     BiomesOPlenty(ModIDs.BiomesOPlenty),
     BloodMagic(ModIDs.BloodMagic),
     Botania(ModIDs.Botania),
@@ -144,6 +145,7 @@ public enum ModUtils implements IMod {
 
         public static final String Angelica = "angelica";
         public static final String Avaritia = "Avaritia";
+        public static final String Backhand = "backhand";
         public static final String BiomesOPlenty = "BiomesOPlenty";
         public static final String BloodMagic = "AWWayofTime";
         public static final String Botania = "Botania";

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -5,8 +5,8 @@
     "description": "Crops - GTNH flavor",
     "version": "${modVersion}",
     "mcversion": "${minecraftVersion}",
-    "url": "http://github.com/GTNewHorizons/GTNHCrops",
-    "updateUrl": "http://github.com/GTNewHorizons/GTNHCrops",
+    "url": "https://github.com/GTNewHorizons/CropsNH",
+    "updateUrl": "https://github.com/GTNewHorizons/CropsNH",
     "authorList": [
       "C0bra5",
       "GTNH Team"


### PR DESCRIPTION
When someone reported the off-hand slot still interacting with the crop sticks while trying to use a watering can, Lyft recommended this when I asked around. Hopefully, it prevents the other hand slot from interacting as well.