### PR TITLE
Correct Ardite Berry Drop Count

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/crops/oreberries/CropArditeOreBerry.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/crops/oreberries/CropArditeOreBerry.java
@@ -16,7 +16,7 @@ public class CropArditeOreBerry extends CropOreBerry {
     public CropArditeOreBerry() {
         super("ardite", new Color(0xAD5A00), new Color(0xFA8100));
 
-        this.addDrop(Materials.Ardite.getNuggets(6), 100_00);
+        this.addDrop(Materials.Ardite.getNuggets(1), 100_00);
 
         this.addBlockUnderRequirement(CropsNHBlockUnderTypes.ardite);
 


### PR DESCRIPTION
Nugget-dropping ore berries are all supposed to drop stack sizes of 1. I gave Ardite Berry a drop size of 6 by mistake when migrating it over from crops++. This PR fixes this issue.