### PR TITLE
Fix mcmod.info URLs

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -5,8 +5,8 @@
     "description": "Crops - GTNH flavor",
     "version": "${modVersion}",
     "mcversion": "${minecraftVersion}",
-    "url": "http://github.com/GTNewHorizons/GTNHCrops",
-    "updateUrl": "http://github.com/GTNewHorizons/GTNHCrops",
+    "url": "https://github.com/GTNewHorizons/CropsNH",
+    "updateUrl": "https://github.com/GTNewHorizons/CropsNH",
     "authorList": [
       "C0bra5",
       "GTNH Team"


### PR DESCRIPTION
Updated the `url` and `updateUrl` fields in `mcmod.info` to point to the correct repo at `https://github.com/GTNewHorizons/CropsNH`.