### PR TITLE
Prevent offhand taking priority when watering crops

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,6 +9,10 @@ dependencies {
     devOnlyNonPublishable("com.github.GTNewHorizons:ForestryMC:4.11.12:dev") { transitive = false }
     devOnlyNonPublishable("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
 
+    compileOnly('com.github.GTNewHorizons:Backhand:1.8.8:dev') { transitive = false }
+    compileOnly(deobfCurse("extra-utilities-225561:2264384")) { transitive = false }
+
+
     // // debugging tools
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:NewHorizonsCoreMod:2.8.195:dev")
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:ServerUtilities:2.2.20:dev") { transitive = false }

--- a/src/main/java/com/gtnewhorizon/cropsnh/compatibility/backhand/BackhandCompat.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/compatibility/backhand/BackhandCompat.java
@@ -1,0 +1,38 @@
+package com.gtnewhorizon.cropsnh.compatibility.backhand;
+
+import static xonin.backhand.api.core.EnumHand.MAIN_HAND;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+
+import com.gtnewhorizon.cropsnh.blocks.BlockCropSticks;
+import com.gtnewhorizon.cropsnh.utility.ModUtils;
+import com.gtnewhorizon.gtnhlib.eventbus.EventBusSubscriber;
+import com.rwtema.extrautils.item.ItemWateringCan;
+
+import cpw.mods.fml.common.eventhandler.EventPriority;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import xonin.backhand.api.core.BackhandUtils;
+
+@EventBusSubscriber
+public class BackhandCompat {
+
+    @EventBusSubscriber.Condition
+    public static boolean register() {
+        return ModUtils.Backhand.isModLoaded() && ModUtils.ExtraUtilities.isModLoaded();
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public static void onPlayerInteract(PlayerInteractEvent event) {
+        if (event.world == null || event.action != PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK
+            || !BackhandUtils.isUsingOffhand(event.entityPlayer)) {
+            return;
+        }
+
+        ItemStack mainHand = MAIN_HAND.getItem(event.entityPlayer);
+        if (mainHand == null || !(mainHand.getItem() instanceof ItemWateringCan)) return;
+        if (event.world.getBlock(event.x, event.y, event.z) instanceof BlockCropSticks) {
+            event.setCanceled(true);
+        }
+    }
+}

--- a/src/main/java/com/gtnewhorizon/cropsnh/utility/ModUtils.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/utility/ModUtils.java
@@ -16,6 +16,7 @@ public enum ModUtils implements IMod {
 
     Angelica(ModIDs.Angelica),
     Avaritia(ModIDs.Avaritia),
+    Backhand(ModIDs.Backhand),
     BiomesOPlenty(ModIDs.BiomesOPlenty),
     BloodMagic(ModIDs.BloodMagic),
     Botania(ModIDs.Botania),
@@ -144,6 +145,7 @@ public enum ModUtils implements IMod {
 
         public static final String Angelica = "angelica";
         public static final String Avaritia = "Avaritia";
+        public static final String Backhand = "backhand";
         public static final String BiomesOPlenty = "BiomesOPlenty";
         public static final String BloodMagic = "AWWayofTime";
         public static final String Botania = "Botania";

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -5,8 +5,8 @@
     "description": "Crops - GTNH flavor",
     "version": "${modVersion}",
     "mcversion": "${minecraftVersion}",
-    "url": "http://github.com/GTNewHorizons/GTNHCrops",
-    "updateUrl": "http://github.com/GTNewHorizons/GTNHCrops",
+    "url": "https://github.com/GTNewHorizons/CropsNH",
+    "updateUrl": "https://github.com/GTNewHorizons/CropsNH",
     "authorList": [
       "C0bra5",
       "GTNH Team"


### PR DESCRIPTION
Cancels the offhand action whenever a crop stick block is targeted while holding a watering can from ExU.

Addresses https://discordapp.com/channels/181078474394566657/401118216228831252/1502146611524931666

Moved from https://github.com/GTNewHorizons/Backhand/pull/183