### PR TITLE
add missing indigo blossom recipes

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
@@ -161,13 +161,11 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
 
     private static void addIndigoBlossomRecipes() {
         // extraction to indigo dye item
-        recipe(2, 15 ,0)
-            .itemInputs(CropsNHItemList.indigoBlossom.get(1))
+        recipe(2, 15, 0).itemInputs(CropsNHItemList.indigoBlossom.get(1))
             .itemOutputs(ItemList.Dye_Indigo.get(1))
             .addTo(extractorRecipes);
         // extraction to indigo dye fluid
-        recipe( 4, 6, 40)
-            .itemInputs(CropsNHItemList.indigoBlossom.get(1))
+        recipe(4, 6, 40).itemInputs(CropsNHItemList.indigoBlossom.get(1))
             .fluidOutputs(getFluidStack("indigo", 1 * INGOTS))
             .addTo(fluidExtractionRecipes);
     }

--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
@@ -156,6 +156,20 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
         addHopsRecipes();
         addCoffeeRecipes();
         addThiosulfineRecipes();
+        addIndigoBlossomRecipes();
+    }
+
+    private static void addIndigoBlossomRecipes() {
+        // extraction to indigo dye item
+        recipe(2, 15 ,0)
+            .itemInputs(CropsNHItemList.indigoBlossom.get(1))
+            .itemOutputs(ItemList.Dye_Indigo.get(1))
+            .addTo(extractorRecipes);
+        // extraction to indigo dye fluid
+        recipe( 4, 6, 40)
+            .itemInputs(CropsNHItemList.indigoBlossom.get(1))
+            .fluidOutputs(getFluidStack("indigo", 1 * INGOTS))
+            .addTo(fluidExtractionRecipes);
     }
 
     private static void addThiosulfineRecipes() {


### PR DESCRIPTION
I missed transferring the recipes over when I migrated the crops from GT5u.

Copied from:
- Item extraction: https://github.com/GTNewHorizons/GT5-Unofficial/blob/e48304dd8f49be6df8e395c835780002bfb4e898/src/main/java/gregtech/common/items/MetaGeneratedItem02.java#L2707-L2712
- Fluid extraction: https://github.com/GTNewHorizons/GT5-Unofficial/blob/e48304dd8f49be6df8e395c835780002bfb4e898/src/main/java/gregtech/loaders/postload/recipes/FluidExtractorRecipes.java#L66-L71

Resolves #121 