### PR TITLE
IF Fertilizer Balance Changes and Growth Speed Fix

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/blocks/BlockFertilizerUnit.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/blocks/BlockFertilizerUnit.java
@@ -42,7 +42,7 @@ public class BlockFertilizerUnit extends CropsNHBlockIndustrialFarmTiredComponen
     }
 
     public static int getFertilizerConsumptionPerCycle(int aTier) {
-        return BlockSeedBed.getWaterConsumption(aTier);
+        return BlockSeedBed.getFertilizerConsumption(aTier);
     }
 
     public void addInformation(ItemStack stack, EntityPlayer player, List<String> tooltip, boolean advancedTooltips) {
@@ -61,26 +61,28 @@ public class BlockFertilizerUnit extends CropsNHBlockIndustrialFarmTiredComponen
             StatCollector.translateToLocalFormatted(
                 Reference.MOD_ID + "_tooltip.fertilizerUnit.1",
                 TooltipHelper.fluidText(getFertilizerConsumptionPerCycle(CropsNHUtils.getItemMeta(stack)))));
+        tooltip.add(StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.fertilizerUnit.2"));
+        tooltip.add(StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.fertilizerUnit.3"));
         if (advancedTooltips) {
             tooltip.add(
                 StatCollector
-                    .translateToLocalFormatted(Reference.MOD_ID + "_tooltip.fertilizerUnit.2.adv", speedIncreaseText));
+                    .translateToLocalFormatted(Reference.MOD_ID + "_tooltip.fertilizerUnit.4.adv", speedIncreaseText));
             tooltip.add(
                 StatCollector
-                    .translateToLocalFormatted(Reference.MOD_ID + "_tooltip.fertilizerUnit.3.adv", roundIncreaseText));
+                    .translateToLocalFormatted(Reference.MOD_ID + "_tooltip.fertilizerUnit.5.adv", roundIncreaseText));
             tooltip.add(
                 StatCollector
-                    .translateToLocalFormatted(Reference.MOD_ID + "_tooltip.fertilizerUnit.4.adv", powerIncreaseText));
+                    .translateToLocalFormatted(Reference.MOD_ID + "_tooltip.fertilizerUnit.6.adv", powerIncreaseText));
         } else {
             tooltip.add(
                 StatCollector
-                    .translateToLocalFormatted(Reference.MOD_ID + "_tooltip.fertilizerUnit.2", speedIncreaseText));
+                    .translateToLocalFormatted(Reference.MOD_ID + "_tooltip.fertilizerUnit.4", speedIncreaseText));
             tooltip.add(
                 StatCollector
-                    .translateToLocalFormatted(Reference.MOD_ID + "_tooltip.fertilizerUnit.3", roundIncreaseText));
+                    .translateToLocalFormatted(Reference.MOD_ID + "_tooltip.fertilizerUnit.5", roundIncreaseText));
             tooltip.add(
                 StatCollector
-                    .translateToLocalFormatted(Reference.MOD_ID + "_tooltip.fertilizerUnit.4", powerIncreaseText));
+                    .translateToLocalFormatted(Reference.MOD_ID + "_tooltip.fertilizerUnit.6", powerIncreaseText));
         }
         // generic
         tooltip.add(StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.upgradeTierMustMatchSeedBed"));

--- a/src/main/java/com/gtnewhorizon/cropsnh/blocks/BlockOverclockedGrowthAccelerationUnit.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/blocks/BlockOverclockedGrowthAccelerationUnit.java
@@ -40,6 +40,7 @@ public class BlockOverclockedGrowthAccelerationUnit extends CropsNHBlockIndustri
         tooltip.add(StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.overclockedGrowthAccelerationUnit.0"));
         tooltip.add(StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.overclockedGrowthAccelerationUnit.1"));
         tooltip.add(StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.overclockedGrowthAccelerationUnit.2"));
+        tooltip.add(StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.overclockedGrowthAccelerationUnit.3"));
         // generic
         tooltip.add(StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.upgradeTierMustMatchSeedBed"));
         tooltip.add(

--- a/src/main/java/com/gtnewhorizon/cropsnh/blocks/BlockSeedBed.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/blocks/BlockSeedBed.java
@@ -14,7 +14,6 @@ import com.gtnewhorizon.cropsnh.api.CropsNHItemList;
 import com.gtnewhorizon.cropsnh.blocks.abstracts.CropsNHBlockIndustrialFarmTiredComponent;
 import com.gtnewhorizon.cropsnh.reference.Names;
 import com.gtnewhorizon.cropsnh.reference.Reference;
-import com.gtnewhorizon.cropsnh.tileentity.TileEntityCropSticks;
 import com.gtnewhorizon.cropsnh.tileentity.multi.MTEIndustrialFarm;
 import com.gtnewhorizon.cropsnh.tileentity.singleblock.MTECropManager;
 import com.gtnewhorizon.cropsnh.utility.CropsNHUtils;
@@ -60,9 +59,8 @@ public class BlockSeedBed extends CropsNHBlockIndustrialFarmTiredComponent {
         // calculate the consumption rate scalar
         for (int i = 0; i < WATER_CONSUMPTION_LOOKUP.length; i++) {
             // scalar amount is computed from max seed capacity.
-            WATER_CONSUMPTION_LOOKUP[i] = (int) Math.ceil(
-                BlockSeedBed.getCapacity(i + MIN_TIER)
-                    * (MTEIndustrialFarm.CYCLE_DURATION / (double) TileEntityCropSticks.TICK_RATE));
+            WATER_CONSUMPTION_LOOKUP[i] = (int) Math
+                .ceil(BlockSeedBed.getCapacity(i + MIN_TIER) * MTEIndustrialFarm.CYCLE_TICK_RATE_SCALAR);
         }
     }
 
@@ -72,6 +70,10 @@ public class BlockSeedBed extends CropsNHBlockIndustrialFarmTiredComponent {
                 String.format("tier should be between %d and %d (was %d)", MIN_TIER, MAX_TIER, aTier));
         }
         return WATER_CONSUMPTION_LOOKUP[aTier - MIN_TIER];
+    }
+
+    public static int getFertilizerConsumption(int aTier) {
+        return getWaterConsumption(aTier);
     }
 
     public static int getCapacity(int aTier) {
@@ -104,23 +106,27 @@ public class BlockSeedBed extends CropsNHBlockIndustrialFarmTiredComponent {
             StatCollector.translateToLocalFormatted(
                 Reference.MOD_ID + "_tooltip.seedBed.2",
                 TooltipHelper.fluidText(getWaterConsumption(tMeta))));
+        aTooltip.add(
+            StatCollector.translateToLocalFormatted(
+                Reference.MOD_ID + "_tooltip.seedBed.3",
+                TooltipHelper.fluidText(getFertilizerConsumption(tMeta))));
         if (aAdvancedTooltips) {
             aTooltip.add(
                 StatCollector
-                    .translateToLocalFormatted(Reference.MOD_ID + "_tooltip.seedBed.3.adv", roundIncreaseText));
+                    .translateToLocalFormatted(Reference.MOD_ID + "_tooltip.seedBed.4.adv", roundIncreaseText));
         } else {
             aTooltip.add(
-                StatCollector.translateToLocalFormatted(Reference.MOD_ID + "_tooltip.seedBed.3", roundIncreaseText));
+                StatCollector.translateToLocalFormatted(Reference.MOD_ID + "_tooltip.seedBed.4", roundIncreaseText));
         }
 
         int length = getMultiLength(tMeta);
         String lengthText = TooltipHelper.tierText(formatNumber(length));
         if (length == 1) {
             aTooltip.add(
-                StatCollector.translateToLocalFormatted(Reference.MOD_ID + "_tooltip.seedBed.4.single", lengthText));
+                StatCollector.translateToLocalFormatted(Reference.MOD_ID + "_tooltip.seedBed.5.single", lengthText));
         } else {
             aTooltip.add(
-                StatCollector.translateToLocalFormatted(Reference.MOD_ID + "_tooltip.seedBed.4.plural", lengthText));
+                StatCollector.translateToLocalFormatted(Reference.MOD_ID + "_tooltip.seedBed.5.plural", lengthText));
         }
 
     }

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
@@ -807,14 +807,14 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
     @Nonnull
     public static final CheckRecipeResult CHECK_RECIPE_RESULT_CANNOT_GROW = SimpleCheckRecipeResult
         .ofFailure(Reference.MOD_ID + ".industrialFarm.cannotGrow");
-    /** Can't generate resources because the growth requires aren't met */
+    /** Can't generate resources because there machine doesn't have enough water. */
     @Nonnull
     public static final CheckRecipeResult NOT_ENOUGH_WATER = SimpleCheckRecipeResult
         .ofFailure(Reference.MOD_ID + ".industrialFarm.notEnoughWater");
-    /** Can't generate resources because the growth requires aren't met */
+    /** Can't generate resources because there isn't enough enriched fertilizer. */
     @Nonnull
-    public static final CheckRecipeResult NOT_ENOUGH_FERTILIZER = SimpleCheckRecipeResult
-        .ofFailure(Reference.MOD_ID + ".industrialFarm.notEnoughFertilizer");
+    public static final CheckRecipeResult NOT_ENOUGH_Enriched_FERTILIZER = SimpleCheckRecipeResult
+        .ofFailure(Reference.MOD_ID + ".industrialFarm.notEnoughEnrichedFertilizer");
 
     @Override
     public @Nonnull CheckRecipeResult checkProcessing() {
@@ -1183,7 +1183,7 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
             if (tFertilizerPotencyMissing <= 0 && tWaterPotencyMissing <= 0) break;
         }
         if (tWaterPotencyMissing > 0) return NOT_ENOUGH_WATER;
-        if (this.mFertilizerUnitCount > 0 && tFertilizerPotencyMissing > 0) return NOT_ENOUGH_FERTILIZER;
+        if (this.mFertilizerUnitCount > 0 && tFertilizerPotencyMissing > 0) return NOT_ENOUGH_Enriched_FERTILIZER;
         this.mHasFertilizer = tFertilizerPotencyMissing <= 0;
 
         // calc drops

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
@@ -1264,17 +1264,17 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
         // calc unscaled growth speed of crop.
         int tUnscaledGrowthSpeed = this.getGrowthSpeedUnscaled(aCrop);
         if (tUnscaledGrowthSpeed <= 0) return -1;
-        // calculate growth points per cycle
-        double tGrowthPerCycle = (((double) tUnscaledGrowthSpeed) / TileEntityCropSticks.TICK_RATE) * CYCLE_DURATION;
-        // apply growth speed multipliers
-        tGrowthPerCycle *= this.getGrowthSpeedMultiplier();
-        if (tGrowthPerCycle <= 0) return -1;
-        // calculate percentage grown each tick.
-        return Math.min(
-            1.0d,
-            1.0d / Math.ceil(
-                aCrop.getCrop()
-                    .getGrowthDuration() / tGrowthPerCycle));
+        // calculate percentage grown each tick up to 100% since growth
+        // don't carry over if you wait to harvest in world crops.
+        // this is intentional balancing and shouldn't be included in the future mega multi.
+        int cropGrowthDuration = aCrop.getCrop()
+            .getGrowthDuration();
+        int growthTicksPerHarvest = (cropGrowthDuration / tUnscaledGrowthSpeed)
+            + (cropGrowthDuration % tUnscaledGrowthSpeed == 0 ? 0 : 1);
+        // calculate percent progress per growth tick
+        double growthPercentPerGrowthTick = 1.0d / growthTicksPerHarvest;
+        // scale it to the cycle's rate and apply growth speed multipliers
+        return growthPercentPerGrowthTick * CYCLE_TICK_RATE_SCALAR * getGrowthSpeedMultiplier();
     }
 
     /**

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
@@ -897,7 +897,12 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
             if (tSeedData.getCrop()
                 .getMinSeedBedTier() > this.mUpgradeTier) return CHECK_RECIPE_RESULT_SEED_BED_TIER_TOO_LOW;
             // check if the crop can grow
-            if (getGrowthSpeedUnscaled(tSeedData) <= 0) return CHECK_RECIPE_RESULT_CANNOT_GROW;
+            boolean tOldHasFertilizer = this.mHasFertilizer;
+            // assume we have fertilizer when inserting to prevent issues with high tier crops that may require it.
+            this.mHasFertilizer = true;
+            int tGrowthSpeedUnscaled = this.getGrowthSpeedUnscaled(tSeedData);
+            this.mHasFertilizer = tOldHasFertilizer;
+            if (tGrowthSpeedUnscaled <= 0) return CHECK_RECIPE_RESULT_CANNOT_GROW;
             // if it has a block under try to consume it
             reqs: for (IGrowthRequirement tRequirement : tSeedData.getCrop()
                 .getGrowthRequirements()) {
@@ -1187,7 +1192,7 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
         this.mHasFertilizer = tFertilizerPotencyMissing <= 0;
 
         // calc drops
-        IFDropTable tDropProgess = getDropsPerCycle(tSeedData);
+        IFDropTable tDropProgess = this.getDropsPerCycle(tSeedData);
         if (tDropProgess == null) return CHECK_RECIPE_RESULT_CANNOT_GROW;
         tDropProgess.addTo(this.mOutputTracker, tSeedData.getStack().stackSize);
         // check if output void protection is enabled

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
@@ -70,6 +70,7 @@ import com.gtnewhorizon.cropsnh.farming.registries.FertilizerRegistry;
 import com.gtnewhorizon.cropsnh.farming.registries.HydrationRegistry;
 import com.gtnewhorizon.cropsnh.farming.requirements.BlockUnderRequirement;
 import com.gtnewhorizon.cropsnh.init.CropsNHBlocks;
+import com.gtnewhorizon.cropsnh.init.CropsNHFluids;
 import com.gtnewhorizon.cropsnh.items.ItemEnvironmentalModule;
 import com.gtnewhorizon.cropsnh.reference.Constants;
 import com.gtnewhorizon.cropsnh.reference.Reference;
@@ -117,18 +118,19 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
     /** Whether the crop can see the sky when calculating the growth speed. (true because uv lamps or something) */
     public static final boolean SIMULATED_CAN_SEE_SKY = true;
     /**
-     * The amount of fertilizer that should be stored in the crop stick when calculating the growth sped while there is
-     * no fertilizer unit installed
+     * The amount of fertilizer that should be stored in the crop stick when calculating the growth speed when
+     * fertilizer is not provided.
      */
-    public static final int SIMULATED_FERTILIZER_STORAGE_WHEN_FERTILIZER_UNIT_MISSING = 20;
+    public static final int SIMULATED_FERTILIZER_STORAGE_WHEN_FERTILIZER_NOT_PROVIDED = 0;
     /**
-     * The amount of fertilizer that should be stored in the crop stick when calculating the growth sped while there is
-     * a fertilizer unit installed
+     * The amount of fertilizer that should be stored in the crop stick when calculating the growth speed when
+     * fertilizer is provided.
      */
-    public static final int SIMULATED_FERTILIZER_STORAGE_WHEN_FERTILIZER_UNIT_INSTALLED = 200;
+    public static final int SIMULATED_FERTILIZER_STORAGE_WHEN_FERTILIZER_PROVIDED = 200;
 
     private final static String NBT_INVENTORY_TAG = "mIFInventory";
     private final static String NBT_OUTPUT_TRACKER = "mOutputTracker";
+    private final static String NBT_HAS_FERTILIZER = "mHasFertilizer";
 
     /** The default mode, used to insert seed and under-block */
     public static final int MODE_INPUT = 0;
@@ -157,6 +159,8 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
     public int mUpgradeTier = -1;
     /** The number of seeds and under-blocks that can be stored in the controller. */
     public int mSeedCapacity = 0;
+    /** True if the current recipe has enough fertilizer to get the bonus. */
+    public boolean mHasFertilizer = false;
     /** The number of environmental enhancement units installed on the multi. */
     public int mEnvironmentalEnhancementUnitCount = 0;
     /** The number of growth acceleration units installed on the multi. */
@@ -650,19 +654,18 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
             StatCollector.translateToLocalFormatted(
                 Reference.MOD_ID + "_tooltip.industrialFarm.scanner.3",
                 formatNumber(this.getGrowthSpeedMultiplier() * 100.0f)));
-        // Water Usage per Cycle
-        int waterUsage = this.getConsumablePotencyNeededPerCycle();
         ret.add(
             StatCollector.translateToLocalFormatted(
                 Reference.MOD_ID + "_tooltip.industrialFarm.scanner.4",
-                formatNumber(waterUsage) + getFluidUnit(),
+                formatNumber(this.getWaterPotencyNeededPerCycle()) + getFluidUnit(),
                 formatNumber(CYCLE_DURATION)));
         // Fertilizer Usage per Cycle
-        int fertUsage = this.mFertilizerUnitCount > 0 ? waterUsage : 0;
+        String fertLangKey = Reference.MOD_ID + "_tooltip.industrialFarm.scanner.5";
+        if (this.mFertilizerUnitCount > 0) fertLangKey += ".enriched";
         ret.add(
             StatCollector.translateToLocalFormatted(
-                Reference.MOD_ID + "_tooltip.industrialFarm.scanner.5",
-                formatNumber(fertUsage) + getFluidUnit(),
+                fertLangKey,
+                formatNumber(this.getFertilizerPotencyNeededPerCycle()) + getFluidUnit(),
                 formatNumber(CYCLE_DURATION)));
         // nutrient score
         ISeedData tSeedData = CropsNHUtils.getAnalyzedSeedData(this.getSeedStack());
@@ -719,6 +722,7 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
             this.mIFStackHandler.deserializeNBT(aNBT.getCompoundTag(NBT_INVENTORY_TAG));
         }
         this.mOutputTracker = new IFDropTable(aNBT, NBT_OUTPUT_TRACKER);
+        this.mHasFertilizer = aNBT.getBoolean(NBT_HAS_FERTILIZER);
     }
 
     @Override
@@ -726,6 +730,7 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
         super.saveNBTData(aNBT);
         aNBT.setTag(NBT_INVENTORY_TAG, this.mIFStackHandler.serializeNBT());
         aNBT.setTag(NBT_OUTPUT_TRACKER, this.mOutputTracker.save());
+        aNBT.setBoolean(NBT_HAS_FERTILIZER, this.mHasFertilizer);
     }
     // endregion NBT
 
@@ -802,6 +807,14 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
     @Nonnull
     public static final CheckRecipeResult CHECK_RECIPE_RESULT_CANNOT_GROW = SimpleCheckRecipeResult
         .ofFailure(Reference.MOD_ID + ".industrialFarm.cannotGrow");
+    /** Can't generate resources because the growth requires aren't met */
+    @Nonnull
+    public static final CheckRecipeResult NOT_ENOUGH_WATER = SimpleCheckRecipeResult
+        .ofFailure(Reference.MOD_ID + ".industrialFarm.notEnoughWater");
+    /** Can't generate resources because the growth requires aren't met */
+    @Nonnull
+    public static final CheckRecipeResult NOT_ENOUGH_FERTILIZER = SimpleCheckRecipeResult
+        .ofFailure(Reference.MOD_ID + ".industrialFarm.notEnoughFertilizer");
 
     @Override
     public @Nonnull CheckRecipeResult checkProcessing() {
@@ -1063,17 +1076,25 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
 
     // region farm mode
 
-    private int getConsumablePotencyNeededPerCycle() {
-        return (int) Math.ceil(
-            this.mSeedCapacity * CYCLE_TICK_RATE_SCALAR
-                * (this.mExpectedOCs <= 63 ? 1L << this.mExpectedOCs : GTUtility.powInt(2.0d, this.mExpectedOCs)));
+    private double getOCPotencyMultiplier() {
+        return this.mExpectedOCs <= 63 ? 1L << this.mExpectedOCs : GTUtility.powInt(2.0d, this.mExpectedOCs);
+    }
+
+    private int getWaterPotencyNeededPerCycle() {
+        return GTUtility.safeInt(
+            (long) Math.ceil(BlockSeedBed.getWaterConsumption(this.mUpgradeTier) * this.getOCPotencyMultiplier()));
+    }
+
+    private int getFertilizerPotencyNeededPerCycle() {
+        return GTUtility.safeInt(
+            (long) Math.ceil(BlockSeedBed.getFertilizerConsumption(this.mUpgradeTier) * this.getOCPotencyMultiplier()));
     }
 
     private int getAmountToConsumeBasedOnPotency(int aMissingPotency, int aInputPotency, int aInputAmount) {
         if (aMissingPotency <= 0 || aInputPotency <= 0 || aInputAmount <= 0) return 0;
         // Prefer over-consuming in case something with a stupid high potency gets introduced.
         int tMaxConsume = aMissingPotency / aInputPotency + ((aMissingPotency % aInputPotency) > 0 ? 1 : 0);
-        return (int) Math.min(tMaxConsume, aInputAmount);
+        return Math.min(tMaxConsume, aInputAmount);
     }
 
     private CheckRecipeResult checkProcessingFarmMode() {
@@ -1117,36 +1138,53 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
         // Math.ceil(Math.ceil(this.mSeedCapacity * CYCLE_DURATION / (double)TileEntityCrop.TICK_RATE * (1 <<
         // this.mExpectedOCs)) / potencyPer1LOfLiquid)
         // Desmos visualizer: https://www.desmos.com/calculator/gmul5gq6cv
-        List<Pair<FluidStack, Integer>> tFluidsToConsume = new ArrayList<>();
-        int tWaterPotencyMissing = this.getConsumablePotencyNeededPerCycle();
-        int tFertilizerPotencyMissing = this.mFertilizerUnitCount > 0 ? tWaterPotencyMissing : 0;
+        List<Pair<FluidStack, Integer>> tWaterFluidsToConsume = new ArrayList<>();
+        List<Pair<FluidStack, Integer>> tFertilizerFluidsToConsume = new ArrayList<>();
+        int tWaterPotencyMissing = this.getWaterPotencyNeededPerCycle();
+        int tFertilizerPotencyMissing = this.getFertilizerPotencyNeededPerCycle();
         for (FluidStack tFluidStack : this.getStoredFluids()) {
             if (CropsNHUtils.isStackInvalid(tFluidStack)) continue;
             Fluid tFluid = tFluidStack.getFluid();
             int tRemaining = tFluidStack.amount;
             int tPotency;
             // consume water if needed
-            if (tWaterPotencyMissing > 0 && (tPotency = HydrationRegistry.instance.getPotency(tFluid)) > 0) {
+            if (tWaterPotencyMissing > 0 && tRemaining > 0
+                && (tPotency = HydrationRegistry.instance.getPotency(tFluid)) > 0) {
                 int tAmountToConsume = getAmountToConsumeBasedOnPotency(tWaterPotencyMissing, tPotency, tRemaining);
-                tRemaining -= tAmountToConsume;
-                tWaterPotencyMissing -= tAmountToConsume * tPotency;
-                tFluidsToConsume.add(Pair.of(tFluidStack, tRemaining));
+                if (tAmountToConsume > 0) {
+                    tRemaining -= tAmountToConsume;
+                    tWaterPotencyMissing -= tAmountToConsume * tPotency;
+                    tWaterFluidsToConsume.add(Pair.of(tFluidStack, tAmountToConsume));
+                }
             }
             // consume fertilizer if needed
-            if (tFertilizerPotencyMissing > 0 && tRemaining > 0
-                && (tPotency = FertilizerRegistry.instance.getPotency(tFluid)) > 0) {
-                int tAmountToConsume = getAmountToConsumeBasedOnPotency(
-                    tFertilizerPotencyMissing,
-                    tPotency,
-                    tRemaining);
-                tRemaining -= tAmountToConsume;
-                tFertilizerPotencyMissing -= tAmountToConsume * tPotency;
-                tFluidsToConsume.add(Pair.of(tFluidStack, tRemaining));
+            if (tFertilizerPotencyMissing > 0 && tRemaining > 0) {
+                if (this.mFertilizerUnitCount > 0) {
+                    // when a fertilizer unit is installed, it can only consume enriched fert,
+                    // and there is no potency bonus applied.
+                    tPotency = tFluidStack.getFluid() == CropsNHFluids.enrichedFertilizer ? 1 : 0;
+                } else {
+                    // else you can use any liquid fertilizer you want.
+                    tPotency = FertilizerRegistry.instance.getPotency(tFluid);
+                }
+                if (tPotency > 0) {
+                    int tAmountToConsume = getAmountToConsumeBasedOnPotency(
+                        tFertilizerPotencyMissing,
+                        tPotency,
+                        tRemaining);
+                    if (tAmountToConsume > 0) {
+                        tRemaining -= tAmountToConsume;
+                        tFertilizerPotencyMissing -= tAmountToConsume * tPotency;
+                        tFertilizerFluidsToConsume.add(Pair.of(tFluidStack, tAmountToConsume));
+                    }
+                }
             }
             // if we consumed something add it to the list for later consumption.
             if (tFertilizerPotencyMissing <= 0 && tWaterPotencyMissing <= 0) break;
         }
-        if (tWaterPotencyMissing > 0 || tFertilizerPotencyMissing > 0) return CheckRecipeResultRegistry.NO_RECIPE;
+        if (tWaterPotencyMissing > 0) return NOT_ENOUGH_WATER;
+        if (this.mFertilizerUnitCount > 0 && tFertilizerPotencyMissing > 0) return NOT_ENOUGH_FERTILIZER;
+        this.mHasFertilizer = tFertilizerPotencyMissing <= 0;
 
         // calc drops
         IFDropTable tDropProgess = getDropsPerCycle(tSeedData);
@@ -1164,8 +1202,13 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
             }
         }
         // consume fluids
-        for (Pair<FluidStack, Integer> tFluidToConsume : tFluidsToConsume) {
-            tFluidToConsume.getLeft().amount = tFluidToConsume.getRight();
+        for (Pair<FluidStack, Integer> tWaterFluidToConsume : tWaterFluidsToConsume) {
+            tWaterFluidToConsume.getLeft().amount -= tWaterFluidToConsume.getRight();
+        }
+        if (this.mHasFertilizer) {
+            for (Pair<FluidStack, Integer> tFertilizerFluidToConsume : tFertilizerFluidsToConsume) {
+                tFertilizerFluidToConsume.getLeft().amount -= tFertilizerFluidToConsume.getRight();
+            }
         }
         // output if everything is safe
         this.mOutputItems = this.mOutputTracker.getDrops(false);
@@ -1211,9 +1254,11 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
             .filter(tBiomeTags::contains)
             .count();
         // calc fertilizer storage to simulate
-        int tFertilizerStorage = this.mFertilizerUnitCount <= 0
-            ? SIMULATED_FERTILIZER_STORAGE_WHEN_FERTILIZER_UNIT_MISSING
-            : SIMULATED_FERTILIZER_STORAGE_WHEN_FERTILIZER_UNIT_INSTALLED;
+        // mHasFert or fert unit installed to make the value consistent when he upgrade is installed since the value
+        // won't change when it's installed.
+        int tFertilizerStorage = this.mHasFertilizer || this.mFertilizerUnitCount > 0
+            ? SIMULATED_FERTILIZER_STORAGE_WHEN_FERTILIZER_PROVIDED
+            : SIMULATED_FERTILIZER_STORAGE_WHEN_FERTILIZER_NOT_PROVIDED;
         // calc available nutrient points for growth speed calculation
         return TileEntityCropSticks.getNutrientsPerCycle(
             tLikedBiomes,

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
@@ -610,7 +610,11 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
             .addGlassEnergyLimitInfo()
             .addInfo(
                 EnumChatFormatting.GREEN
-                    + StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.MBTT.multiAmpsWithUpgrade")
+                    + StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.MBTT.multiAmpsWithUpgrade.0")
+                    + EnumChatFormatting.RESET)
+            .addInfo(
+                EnumChatFormatting.GREEN
+                    + StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.MBTT.multiAmpsWithUpgrade.1")
                     + EnumChatFormatting.RESET)
             .addCasingInfoRange(
                 StatCollector.translateToLocal(Reference.MOD_ID + ".casings1.0.name"),

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
@@ -127,6 +127,10 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
      * fertilizer is provided.
      */
     public static final int SIMULATED_FERTILIZER_STORAGE_WHEN_FERTILIZER_PROVIDED = 200;
+    /**
+     * The maximum number of multi-amp hatches allowed when using an OC upgrade.
+     */
+    public static final int MAX_MULTIAMP_EHATCH_AMOUNT = 1;
 
     private final static String NBT_INVENTORY_TAG = "mIFInventory";
     private final static String NBT_OUTPUT_TRACKER = "mOutputTracker";
@@ -472,8 +476,16 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
             return false;
         }
 
-        // validate hatches depending on the presence of the oc upgrade.
+        // validate exotic hatches depending on the presence of the oc upgrade.
         if (this.mOverclockedGrowthAccelerationUnitCount > 0) {
+            // limit the number of multi-amp hatches
+            if (this.mExoticEnergyHatches.size() > MAX_MULTIAMP_EHATCH_AMOUNT) {
+                return false;
+            }
+            // can't mix and match when using multi-amps
+            if (!this.mExoticEnergyHatches.isEmpty() && !this.mEnergyHatches.isEmpty()) {
+                return false;
+            }
             for (MTEHatch hatch : this.mExoticEnergyHatches) {
                 if (hatch.getConnectionType() == MTEHatch.ConnectionType.LASER) {
                     return false;
@@ -483,7 +495,7 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
                     return false;
                 }
             }
-        } else if (this.mExoticEnergyHatches.size() != 0) {
+        } else if (!this.mExoticEnergyHatches.isEmpty()) {
             return false;
         }
 

--- a/src/main/resources/assets/cropsnh/lang/en_US.lang
+++ b/src/main/resources/assets/cropsnh/lang/en_US.lang
@@ -444,7 +444,7 @@ cropsnh.advancedHarvestingUnit.13.name=Advanced Harvesting Unit (UXV)
 
 # MTE Machine Type Flavour Text
 # multi tooltips
-cropsnh_tooltip.MBTT.multiAmpsWithUpgrade.0=Supports a single TecTech Multi-Amp Energy Hatch when an Overclocked Growth Acceleration Unit!
+cropsnh_tooltip.MBTT.multiAmpsWithUpgrade.0=Supports a single TecTech Multi-Amp Energy Hatch when using an Overclocked Growth Acceleration Unit!
 cropsnh_tooltip.MBTT.multiAmpsWithUpgrade.1=You cannot use regular hatches when using a Multi-Amp Energy Hatch
 # Crop Produce Flavour Text
 cropsnh_tooltip.berry.huckle.1=Huckle-dae-Duckle-dae-Doo

--- a/src/main/resources/assets/cropsnh/lang/en_US.lang
+++ b/src/main/resources/assets/cropsnh/lang/en_US.lang
@@ -348,8 +348,9 @@ cropsnh.seedBed.13.name=Seed Bed (UXV)
 
 # OC Growth Accel Unit
 cropsnh_tooltip.overclockedGrowthAccelerationUnit.0=Allows §foverclocking§7 of the Industrial Farm
-cropsnh_tooltip.overclockedGrowthAccelerationUnit.1=Each overclock §bdoubles§7 production without affecting recipe time
+cropsnh_tooltip.overclockedGrowthAccelerationUnit.1=Each overclock §bdoubles§7 production and input consumption without affecting recipe time
 cropsnh_tooltip.overclockedGrowthAccelerationUnit.2=Won't work if a §fGrowth Acceleration Unit§7 is also present
+cropsnh_tooltip.overclockedGrowthAccelerationUnit.3=Allows for the use of a single TecTech Multi-Amp Energy Hatch instead of multiple regular energy hatches
 cropsnh.overclockedGrowthAccelerationUnit.7.name=Overclocked Growth Acceleration Unit (ZPM)
 cropsnh.overclockedGrowthAccelerationUnit.8.name=Overclocked Growth Acceleration Unit (UV)
 cropsnh.overclockedGrowthAccelerationUnit.9.name=Overclocked Growth Acceleration Unit (UHV)
@@ -443,7 +444,7 @@ cropsnh.advancedHarvestingUnit.13.name=Advanced Harvesting Unit (UXV)
 
 # MTE Machine Type Flavour Text
 # multi tooltips
-cropsnh_tooltip.MBTT.multiAmpsWithUpgrade=Supports TecTech Multi-Amp Hatches when using an Overclocked Growth Accelerator Upgrade!
+cropsnh_tooltip.MBTT.multiAmpsWithUpgrade=Supports a single TecTech Multi-Amp Energy Hatch instead of a regular hatches when using an Overclocked Growth Accelerator Upgrade!
 # Crop Produce Flavour Text
 cropsnh_tooltip.berry.huckle.1=Huckle-dae-Duckle-dae-Doo
 cropsnh_tooltip.berry.huckle.2=A sweet treat!

--- a/src/main/resources/assets/cropsnh/lang/en_US.lang
+++ b/src/main/resources/assets/cropsnh/lang/en_US.lang
@@ -445,7 +445,7 @@ cropsnh.advancedHarvestingUnit.13.name=Advanced Harvesting Unit (UXV)
 # MTE Machine Type Flavour Text
 # multi tooltips
 cropsnh_tooltip.MBTT.multiAmpsWithUpgrade.0=Supports a single TecTech Multi-Amp Energy Hatch when an Overclocked Growth Acceleration Unit!
-cropsnh_tooltip.MBTT.multiAmpsWithUpgrade.1=You cannot use regular hatches when using a Multi-Amp Energy Hatch.
+cropsnh_tooltip.MBTT.multiAmpsWithUpgrade.1=You cannot use regular hatches when using a Multi-Amp Energy Hatch
 # Crop Produce Flavour Text
 cropsnh_tooltip.berry.huckle.1=Huckle-dae-Duckle-dae-Doo
 cropsnh_tooltip.berry.huckle.2=A sweet treat!

--- a/src/main/resources/assets/cropsnh/lang/en_US.lang
+++ b/src/main/resources/assets/cropsnh/lang/en_US.lang
@@ -310,6 +310,8 @@ GT5U.gui.text.cropsnh.industrialFarm.seedBedTierTooLow=The current tier of Seed 
 GT5U.gui.text.cropsnh.industrialFarm.seedsFull=Seed capacity reached
 GT5U.gui.text.cropsnh.industrialFarm.seedOverflow=Seed Storage exceeds current capacity
 GT5U.gui.text.cropsnh.industrialFarm.cannotGrow=This seed cannot grow in the current environment
+GT5U.gui.text.cropsnh.industrialFarm.notEnoughWater=Not enough water
+GT5U.gui.text.cropsnh.industrialFarm.notEnoughFertilizer=Not enough Fertilizer
 
 # Industrial Farm Scanner Tooltips
 cropsnh_tooltip.industrialFarm.scanner.0=Tier: §e%1$s§r
@@ -318,6 +320,7 @@ cropsnh_tooltip.industrialFarm.scanner.2=Harvest Bonus: §e%1$s§r%%
 cropsnh_tooltip.industrialFarm.scanner.3=Growth Speed Bonus: §e%1$s§r%%
 cropsnh_tooltip.industrialFarm.scanner.4=Water Usage: §e%1$s§r/§e%2$s§rt
 cropsnh_tooltip.industrialFarm.scanner.5=Fertilizer Usage: §e%1$s§r/§e%2$s§rt
+cropsnh_tooltip.industrialFarm.scanner.5.enriched=Enriched Fertilizer Usage: §e%1$s§r/§e%2$s§rt
 cropsnh_tooltip.industrialFarm.scanner.6=Nutrient Score: §e%1$s§r out of §e%2$s§r
 
 # Seed Bed
@@ -325,10 +328,11 @@ cropsnh_tooltip.seedBed.name=Seed Bed (%1$s)
 cropsnh_tooltip.seedBed.0=Determines the §ctier§7 of the Industrial Farm
 cropsnh_tooltip.seedBed.1=Seed Capacity: %1$s
 cropsnh_tooltip.seedBed.2=Requires %1$s of water per cycle
-cropsnh_tooltip.seedBed.3=Increases number of drops by %1$s
-cropsnh_tooltip.seedBed.3.adv=Increases number of drops by %1$s (additive)
-cropsnh_tooltip.seedBed.4.single=Farm must have exactly %1$s middle slice
-cropsnh_tooltip.seedBed.4.plural=Farm must have exactly %1$s middle slices
+cropsnh_tooltip.seedBed.3=Optionally uses %1$s of fertilizer per cycle
+cropsnh_tooltip.seedBed.4=Increases number of drops by %1$s
+cropsnh_tooltip.seedBed.4.adv=Increases number of drops by %1$s (additive)
+cropsnh_tooltip.seedBed.5.single=Farm must have exactly %1$s middle slice
+cropsnh_tooltip.seedBed.5.plural=Farm must have exactly %1$s middle slices
 cropsnh.seedBed.2.name=Seed Bed (MV)
 cropsnh.seedBed.3.name=Seed Bed (HV)
 cropsnh.seedBed.4.name=Seed Bed (EV)
@@ -375,14 +379,16 @@ cropsnh.growthAccelerationUnit.12.name=Growth Acceleration Unit (UMV)
 cropsnh.growthAccelerationUnit.13.name=Growth Acceleration Unit (UXV)
 
 # Fertilizer Unit
-cropsnh_tooltip.fertilizerUnit.0=Allows the Industrial Farm to consume §fFertilizer§7 in order to boost production
-cropsnh_tooltip.fertilizerUnit.1=Requires %1$s of Fertilizer per cycle
-cropsnh_tooltip.fertilizerUnit.2=Increases growth speed by %1$s
-cropsnh_tooltip.fertilizerUnit.2.adv=Increases growth speed by %1$s (multiplicative)
-cropsnh_tooltip.fertilizerUnit.3=Increases number of drops by %1$s
-cropsnh_tooltip.fertilizerUnit.3.adv=Increases number of drops by %1$s (additive)
-cropsnh_tooltip.fertilizerUnit.4=Increases power usage by %1$s
-cropsnh_tooltip.fertilizerUnit.4.adv=Increases power usage by %1$s (additive)
+cropsnh_tooltip.fertilizerUnit.0=Allows the Industrial Farm to consume §fEnriched Fertilizer§7 in order to boost production
+cropsnh_tooltip.fertilizerUnit.1=Requires %1$s of §fEnriched Fertilizer§7 per cycle
+cropsnh_tooltip.fertilizerUnit.2=§cYou cannot use regular fertilizer when this unit is installed§7
+cropsnh_tooltip.fertilizerUnit.3=§cIgnores the potency bonus of enriched fertilizer§7
+cropsnh_tooltip.fertilizerUnit.4=Increases growth speed by %1$s
+cropsnh_tooltip.fertilizerUnit.4.adv=Increases growth speed by %1$s (multiplicative)
+cropsnh_tooltip.fertilizerUnit.5=Increases number of drops by %1$s
+cropsnh_tooltip.fertilizerUnit.5.adv=Increases number of drops by %1$s (additive)
+cropsnh_tooltip.fertilizerUnit.6=Increases power usage by %1$s
+cropsnh_tooltip.fertilizerUnit.6.adv=Increases power usage by %1$s (additive)
 cropsnh.fertilizerUnit.2.name=Fertilization Unit (MV)
 cropsnh.fertilizerUnit.3.name=Fertilization Unit (HV)
 cropsnh.fertilizerUnit.4.name=Fertilization Unit (EV)

--- a/src/main/resources/assets/cropsnh/lang/en_US.lang
+++ b/src/main/resources/assets/cropsnh/lang/en_US.lang
@@ -444,7 +444,8 @@ cropsnh.advancedHarvestingUnit.13.name=Advanced Harvesting Unit (UXV)
 
 # MTE Machine Type Flavour Text
 # multi tooltips
-cropsnh_tooltip.MBTT.multiAmpsWithUpgrade=Supports a single TecTech Multi-Amp Energy Hatch instead of a regular hatches when using an Overclocked Growth Accelerator Upgrade!
+cropsnh_tooltip.MBTT.multiAmpsWithUpgrade.0=Supports a single TecTech Multi-Amp Energy Hatch when an Overclocked Growth Acceleration Unit!
+cropsnh_tooltip.MBTT.multiAmpsWithUpgrade.1=You cannot use regular hatches when using a Multi-Amp Energy Hatch.
 # Crop Produce Flavour Text
 cropsnh_tooltip.berry.huckle.1=Huckle-dae-Duckle-dae-Doo
 cropsnh_tooltip.berry.huckle.2=A sweet treat!

--- a/src/main/resources/assets/cropsnh/lang/en_US.lang
+++ b/src/main/resources/assets/cropsnh/lang/en_US.lang
@@ -311,7 +311,7 @@ GT5U.gui.text.cropsnh.industrialFarm.seedsFull=Seed capacity reached
 GT5U.gui.text.cropsnh.industrialFarm.seedOverflow=Seed Storage exceeds current capacity
 GT5U.gui.text.cropsnh.industrialFarm.cannotGrow=This seed cannot grow in the current environment
 GT5U.gui.text.cropsnh.industrialFarm.notEnoughWater=Not enough water
-GT5U.gui.text.cropsnh.industrialFarm.notEnoughFertilizer=Not enough Fertilizer
+GT5U.gui.text.cropsnh.industrialFarm.notEnoughEnrichedFertilizer=Not enough Enriched Fertilizer
 
 # Industrial Farm Scanner Tooltips
 cropsnh_tooltip.industrialFarm.scanner.0=Tier: §e%1$s§r

--- a/src/main/resources/assets/cropsnh/lang/en_US.lang
+++ b/src/main/resources/assets/cropsnh/lang/en_US.lang
@@ -381,8 +381,8 @@ cropsnh.growthAccelerationUnit.13.name=Growth Acceleration Unit (UXV)
 # Fertilizer Unit
 cropsnh_tooltip.fertilizerUnit.0=Allows the Industrial Farm to consume §fEnriched Fertilizer§7 in order to boost production
 cropsnh_tooltip.fertilizerUnit.1=Requires %1$s of §fEnriched Fertilizer§7 per cycle
-cropsnh_tooltip.fertilizerUnit.2=§cYou cannot use regular fertilizer when this unit is installed§7
-cropsnh_tooltip.fertilizerUnit.3=§cIgnores the potency bonus of enriched fertilizer§7
+cropsnh_tooltip.fertilizerUnit.2=§cYou cannot use regular Fertilizer when this unit is installed§7
+cropsnh_tooltip.fertilizerUnit.3=§cIgnores the potency bonus of Enriched Fertilizer§7
 cropsnh_tooltip.fertilizerUnit.4=Increases growth speed by %1$s
 cropsnh_tooltip.fertilizerUnit.4.adv=Increases growth speed by %1$s (multiplicative)
 cropsnh_tooltip.fertilizerUnit.5=Increases number of drops by %1$s


### PR DESCRIPTION
> [!IMPORTANT]
>
> This PR has a sister PR to update the quest book: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/24719

This PR addresses a couple of issues with the industrial farm and tweaks some of its fertilizer-related mechanics:
- Fixes a critical issue that caused the growth speed multiplier to be incorrectly applied during the growth simulation, causing crops to be able to be harvested only once per simulated cycle.
- Fixes a critical issue that caused the OC GAU upgrade to allow more than 1 multi-amp energy hatch.
- Fixes a critical issue that allowed the usage of multi-amp upgrades and regular hatches at the same time when using an OC GAU upgrade.
- The Fertilization Unit now requires players to use Enriched Fertilizer and disables the potency bonus of Enriched Fertilizer, effectively increasing the Enriched Fertilizer usage by 10x when using the upgrade.
  - With the fix to the growth speed formula in place, the Fertilization Unit is now significantly stronger at later stages since its main bonus is its multiplicative growth speed boost. This tweak should help counteract the changes and require higher levels of infrastructure investment to use it at later stages, when the OC GAU comes into play.
- Regular and Enriched Liquid Fertilizers can now be used at any time, and are consumed at the same speed as regular crops would, to provide the expected nutrient score bonus when no Fertilization Unit is installed.
- When inserting seeds, the IF assumes it will have fertilizer when checking if a seed can grow in the current environment.
  - It will still fail to grow if no fertilizer is supplied in farm mode, and the IF will correctly state that it cannot grow in the current environment.

All tooltips have been updated to reflect the above changes:
- Seed Beds now state the optional fertilizer consumption.
- Fertilization Units now state the Enriched Fertilizer requirement and potency bonus disabling.
- The scanner will now indicate when enriched fertilizer is required.
- The nutrient score shown when using a GT Portable Scanner now reflects the fertilization status of the last cycle run by the machine.
- The industrial farm now correctly states a lack of water or enriched fertilizer when it fails to start a cycle.
- The industrial farm's structure and OC GAU upgrade tooltips now correctly state that only a single multi-amp upgrade can be used when using the OC upgrade, and that it cannot be used at the same time as regular energy hatches.

Seed Bed Tooltip:
<img width="775" height="396" alt="image" src="https://github.com/user-attachments/assets/f21ca2cf-114a-4087-ad56-de95ea024bfa" />

Fertilization Unit Tooltip:
<img width="1335" height="452" alt="image" src="https://github.com/user-attachments/assets/23d5fbb3-8e9b-4ed0-9a55-e03f65709f93" />

IF GT Portable Scanner output when no Fertilization Unit is installed:
<img width="488" height="226" alt="image" src="https://github.com/user-attachments/assets/9087fa09-8040-46ee-956d-6c2e360fd84b" />

IF GT Portable Scanner output when a Fertilization Unit is installed:
<img width="607" height="191" alt="image" src="https://github.com/user-attachments/assets/96295749-b9dd-47ee-be33-967b87cea724" />

Fail message for not enough fertilizer:
<img width="491" height="78" alt="image" src="https://github.com/user-attachments/assets/0889914e-6706-430b-85ca-10918d265d3f" />

Fail message for not enough water:
<img width="315" height="71" alt="image" src="https://github.com/user-attachments/assets/c4e1f8e6-2c67-429d-aa4e-950cc8f91c5a" />

OC upgrade and IF Structure Multi-Amp corrections:
<img width="1633" height="443" alt="image" src="https://github.com/user-attachments/assets/3ffefc4c-9f65-4362-9b59-e1b762e62518" />
<img width="1501" height="415" alt="image" src="https://github.com/user-attachments/assets/4c70edb0-ee78-479f-8292-18915d32ec13" />