### PR TITLE
Remove deterministic parent collision for tuff lily

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/api/CropsNHBlockUnderTypes.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/api/CropsNHBlockUnderTypes.java
@@ -16,9 +16,9 @@ public final class CropsNHBlockUnderTypes {
     public static final BlockUnderRequirement blackGranite = BlockUnderRequirement.get("blackGranite");
     public static final BlockUnderRequirement marble = BlockUnderRequirement.get("marble");
     public static final BlockUnderRequirement basalt = BlockUnderRequirement.get("basalt");
-    public static final BlockUnderRequirement botaniaAndesite = BlockUnderRequirement.get("botaniaAndesite");
-    public static final BlockUnderRequirement botaniaDiorite = BlockUnderRequirement.get("botaniaDiorite");
-    public static final BlockUnderRequirement botaniaGranite = BlockUnderRequirement.get("botaniaGranite");
+    public static final BlockUnderRequirement modernAndesite = BlockUnderRequirement.get("modernAndesite");
+    public static final BlockUnderRequirement modernDiorite = BlockUnderRequirement.get("modernDiorite");
+    public static final BlockUnderRequirement modernGranite = BlockUnderRequirement.get("modernGranite");
     public static final BlockUnderRequirement tuff = BlockUnderRequirement.get("tuff");
     public static final BlockUnderRequirement deepslate = BlockUnderRequirement.get("deepslate");
     public static final BlockUnderRequirement coal = BlockUnderRequirement.get("coal");

--- a/src/main/java/com/gtnewhorizon/cropsnh/api/CropsNHCrops.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/api/CropsNHCrops.java
@@ -162,7 +162,7 @@ public class CropsNHCrops {
     public static ICropCard TinOreBerry;
     public static ICropCard VoidOreBerry;
 
-    // Stone Lilies (Botania)
+    // Stone Lilies (modern)
     public static ICropCard AndesiteLily;
     public static ICropCard DioriteLily;
     public static ICropCard GraniteLily;

--- a/src/main/java/com/gtnewhorizon/cropsnh/crops/stoneilies/botania/CropAndesiteLily.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/crops/stoneilies/botania/CropAndesiteLily.java
@@ -6,6 +6,7 @@ import net.minecraftforge.common.BiomeDictionary;
 
 import com.gtnewhorizon.cropsnh.api.CropsNHBlockUnderTypes;
 import com.gtnewhorizon.cropsnh.crops.abstracts.CropBaseStoneLily;
+import com.gtnewhorizon.cropsnh.utility.ModUtils;
 import com.gtnewhorizon.cropsnh.utility.OreDictHelper;
 
 public class CropAndesiteLily extends CropBaseStoneLily {
@@ -13,7 +14,13 @@ public class CropAndesiteLily extends CropBaseStoneLily {
     public CropAndesiteLily() {
         super("andesite", new Color(0x6B6B6A), new Color(0x989896));
 
-        this.addDrop(OreDictHelper.getCopiedOreStack("stoneAndesite", 1), 100_00);
+        final int DROP_COUNT = 1;
+        final int DROP_CHANCE = 100_00;
+        if (ModUtils.Botania.isModLoaded() || ModUtils.EtFuturumRequiem.isModLoaded()) {
+            this.addDrop(OreDictHelper.getCopiedOreStack("stoneAndesite", DROP_COUNT), DROP_CHANCE);
+        } else {
+            this.addDrop(ModUtils.Chisel.getStack("andesite", DROP_COUNT, 0), DROP_CHANCE);
+        }
 
         this.addBlockUnderRequirement(CropsNHBlockUnderTypes.botaniaAndesite);
 

--- a/src/main/java/com/gtnewhorizon/cropsnh/crops/stoneilies/botania/CropDioriteLily.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/crops/stoneilies/botania/CropDioriteLily.java
@@ -6,6 +6,7 @@ import net.minecraftforge.common.BiomeDictionary;
 
 import com.gtnewhorizon.cropsnh.api.CropsNHBlockUnderTypes;
 import com.gtnewhorizon.cropsnh.crops.abstracts.CropBaseStoneLily;
+import com.gtnewhorizon.cropsnh.utility.ModUtils;
 import com.gtnewhorizon.cropsnh.utility.OreDictHelper;
 
 public class CropDioriteLily extends CropBaseStoneLily {
@@ -13,7 +14,13 @@ public class CropDioriteLily extends CropBaseStoneLily {
     public CropDioriteLily() {
         super("diorite", new Color(0x909091), new Color(0xCECED0));
 
-        this.addDrop(OreDictHelper.getCopiedOreStack("stoneDiorite", 1), 100_00);
+        final int DROP_COUNT = 1;
+        final int DROP_CHANCE = 100_00;
+        if (ModUtils.Botania.isModLoaded() || ModUtils.EtFuturumRequiem.isModLoaded()) {
+            this.addDrop(OreDictHelper.getCopiedOreStack("stoneDiorite", DROP_COUNT), DROP_CHANCE);
+        } else {
+            this.addDrop(ModUtils.Chisel.getStack("diorite", DROP_COUNT, 0), DROP_CHANCE);
+        }
 
         this.addBlockUnderRequirement(CropsNHBlockUnderTypes.botaniaDiorite);
 

--- a/src/main/java/com/gtnewhorizon/cropsnh/crops/stoneilies/botania/CropGraniteLily.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/crops/stoneilies/botania/CropGraniteLily.java
@@ -6,6 +6,7 @@ import net.minecraftforge.common.BiomeDictionary;
 
 import com.gtnewhorizon.cropsnh.api.CropsNHBlockUnderTypes;
 import com.gtnewhorizon.cropsnh.crops.abstracts.CropBaseStoneLily;
+import com.gtnewhorizon.cropsnh.utility.ModUtils;
 import com.gtnewhorizon.cropsnh.utility.OreDictHelper;
 
 public class CropGraniteLily extends CropBaseStoneLily {
@@ -13,7 +14,13 @@ public class CropGraniteLily extends CropBaseStoneLily {
     public CropGraniteLily() {
         super("granite", new Color(0x82675B), new Color(0xBA9583));
 
-        this.addDrop(OreDictHelper.getCopiedOreStack("stoneGranite", 1), 100_00);
+        final int DROP_COUNT = 1;
+        final int DROP_CHANCE = 100_00;
+        if (ModUtils.Botania.isModLoaded() || ModUtils.EtFuturumRequiem.isModLoaded()) {
+            this.addDrop(OreDictHelper.getCopiedOreStack("stoneGranite", DROP_COUNT), DROP_CHANCE);
+        } else {
+            this.addDrop(ModUtils.Chisel.getStack("granite", DROP_COUNT, 0), DROP_CHANCE);
+        }
 
         this.addBlockUnderRequirement(CropsNHBlockUnderTypes.botaniaGranite);
 

--- a/src/main/java/com/gtnewhorizon/cropsnh/crops/stoneilies/modern/CropAndesiteLily.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/crops/stoneilies/modern/CropAndesiteLily.java
@@ -1,13 +1,17 @@
-package com.gtnewhorizon.cropsnh.crops.stoneilies.botania;
+package com.gtnewhorizon.cropsnh.crops.stoneilies.modern;
 
 import java.awt.Color;
 
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.BiomeDictionary;
 
 import com.gtnewhorizon.cropsnh.api.CropsNHBlockUnderTypes;
 import com.gtnewhorizon.cropsnh.crops.abstracts.CropBaseStoneLily;
 import com.gtnewhorizon.cropsnh.utility.ModUtils;
 import com.gtnewhorizon.cropsnh.utility.OreDictHelper;
+
+import cpw.mods.fml.common.registry.GameRegistry;
 
 public class CropAndesiteLily extends CropBaseStoneLily {
 
@@ -18,11 +22,15 @@ public class CropAndesiteLily extends CropBaseStoneLily {
         final int DROP_CHANCE = 100_00;
         if (ModUtils.Botania.isModLoaded() || ModUtils.EtFuturumRequiem.isModLoaded()) {
             this.addDrop(OreDictHelper.getCopiedOreStack("stoneAndesite", DROP_COUNT), DROP_CHANCE);
-        } else {
-            this.addDrop(ModUtils.Chisel.getStack("andesite", DROP_COUNT, 0), DROP_CHANCE);
+        } else if (ModUtils.Chisel.isModLoaded()) {
+            // gotta check if the block was registered since it's a config.
+            Block efrStone = GameRegistry.findBlock(ModUtils.EtFuturumRequiem.ID, "stone");
+            if (efrStone != null) {
+                this.addDrop(new ItemStack(efrStone, DROP_COUNT, 5), DROP_CHANCE);
+            }
         }
 
-        this.addBlockUnderRequirement(CropsNHBlockUnderTypes.botaniaAndesite);
+        this.addBlockUnderRequirement(CropsNHBlockUnderTypes.modernAndesite);
 
         this.addLikedBiomes(BiomeDictionary.Type.MOUNTAIN, BiomeDictionary.Type.HILLS);
     }

--- a/src/main/java/com/gtnewhorizon/cropsnh/crops/stoneilies/modern/CropDioriteLily.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/crops/stoneilies/modern/CropDioriteLily.java
@@ -1,13 +1,17 @@
-package com.gtnewhorizon.cropsnh.crops.stoneilies.botania;
+package com.gtnewhorizon.cropsnh.crops.stoneilies.modern;
 
 import java.awt.Color;
 
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.BiomeDictionary;
 
 import com.gtnewhorizon.cropsnh.api.CropsNHBlockUnderTypes;
 import com.gtnewhorizon.cropsnh.crops.abstracts.CropBaseStoneLily;
 import com.gtnewhorizon.cropsnh.utility.ModUtils;
 import com.gtnewhorizon.cropsnh.utility.OreDictHelper;
+
+import cpw.mods.fml.common.registry.GameRegistry;
 
 public class CropDioriteLily extends CropBaseStoneLily {
 
@@ -18,11 +22,15 @@ public class CropDioriteLily extends CropBaseStoneLily {
         final int DROP_CHANCE = 100_00;
         if (ModUtils.Botania.isModLoaded() || ModUtils.EtFuturumRequiem.isModLoaded()) {
             this.addDrop(OreDictHelper.getCopiedOreStack("stoneDiorite", DROP_COUNT), DROP_CHANCE);
-        } else {
-            this.addDrop(ModUtils.Chisel.getStack("diorite", DROP_COUNT, 0), DROP_CHANCE);
+        } else if (ModUtils.Chisel.isModLoaded()) {
+            // gotta check if the block was registered since it's a config.
+            Block efrStone = GameRegistry.findBlock(ModUtils.EtFuturumRequiem.ID, "stone");
+            if (efrStone != null) {
+                this.addDrop(new ItemStack(efrStone, DROP_COUNT, 3), DROP_CHANCE);
+            }
         }
 
-        this.addBlockUnderRequirement(CropsNHBlockUnderTypes.botaniaDiorite);
+        this.addBlockUnderRequirement(CropsNHBlockUnderTypes.modernDiorite);
 
         this.addLikedBiomes(BiomeDictionary.Type.MOUNTAIN, BiomeDictionary.Type.HILLS);
     }

--- a/src/main/java/com/gtnewhorizon/cropsnh/crops/stoneilies/modern/CropGraniteLily.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/crops/stoneilies/modern/CropGraniteLily.java
@@ -1,13 +1,17 @@
-package com.gtnewhorizon.cropsnh.crops.stoneilies.botania;
+package com.gtnewhorizon.cropsnh.crops.stoneilies.modern;
 
 import java.awt.Color;
 
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.BiomeDictionary;
 
 import com.gtnewhorizon.cropsnh.api.CropsNHBlockUnderTypes;
 import com.gtnewhorizon.cropsnh.crops.abstracts.CropBaseStoneLily;
 import com.gtnewhorizon.cropsnh.utility.ModUtils;
 import com.gtnewhorizon.cropsnh.utility.OreDictHelper;
+
+import cpw.mods.fml.common.registry.GameRegistry;
 
 public class CropGraniteLily extends CropBaseStoneLily {
 
@@ -16,13 +20,17 @@ public class CropGraniteLily extends CropBaseStoneLily {
 
         final int DROP_COUNT = 1;
         final int DROP_CHANCE = 100_00;
-        if (ModUtils.Botania.isModLoaded() || ModUtils.EtFuturumRequiem.isModLoaded()) {
+        if (ModUtils.Chisel.isModLoaded() || ModUtils.Botania.isModLoaded()) {
             this.addDrop(OreDictHelper.getCopiedOreStack("stoneGranite", DROP_COUNT), DROP_CHANCE);
-        } else {
-            this.addDrop(ModUtils.Chisel.getStack("granite", DROP_COUNT, 0), DROP_CHANCE);
+        } else if (ModUtils.EtFuturumRequiem.isModLoaded()) {
+            // gotta check if the block was registered since it's a config.
+            Block efrStone = GameRegistry.findBlock(ModUtils.EtFuturumRequiem.ID, "stone");
+            if (efrStone != null) {
+                this.addDrop(new ItemStack(efrStone, DROP_COUNT, 1), DROP_CHANCE);
+            }
         }
 
-        this.addBlockUnderRequirement(CropsNHBlockUnderTypes.botaniaGranite);
+        this.addBlockUnderRequirement(CropsNHBlockUnderTypes.modernGranite);
 
         this.addLikedBiomes(BiomeDictionary.Type.MOUNTAIN, BiomeDictionary.Type.HILLS);
     }

--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/BlockUnderRequirementLoader.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/BlockUnderRequirementLoader.java
@@ -1,5 +1,6 @@
 package com.gtnewhorizon.cropsnh.loaders;
 
+import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 
 import com.gtnewhorizon.cropsnh.api.BlockWithMeta;
@@ -7,6 +8,7 @@ import com.gtnewhorizon.cropsnh.api.CropsNHBlockUnderTypes;
 import com.gtnewhorizon.cropsnh.utility.ModUtils;
 
 import bartworks.system.material.WerkstoffLoader;
+import cpw.mods.fml.common.registry.GameRegistry;
 import gregtech.api.GregTechAPI;
 import gregtech.api.enums.Materials;
 
@@ -33,10 +35,10 @@ public class BlockUnderRequirementLoader {
         CropsNHBlockUnderTypes.blackGranite.addOreDict("stoneGraniteBlack");
         CropsNHBlockUnderTypes.marble.addOreDict("stoneMarble");
         CropsNHBlockUnderTypes.basalt.addOreDict("stoneBasalt");
-        // Botania Stone Lilies
-        CropsNHBlockUnderTypes.botaniaAndesite.addOreDict("stoneAndesite", "stoneAndesitePolished", "stoneAndesiteBricks", "stoneAndesiteChiseled");
-        CropsNHBlockUnderTypes.botaniaDiorite.addOreDict("stoneDiorite", "stoneDioritePolished", "stoneDioriteBricks", "stoneDioriteChiseled");
-        CropsNHBlockUnderTypes.botaniaGranite.addOreDict("stoneGranite", "stoneGranitePolished", "stoneGraniteBricks", "stoneGraniteChiseled");
+        // Modern Stone Lilies
+        CropsNHBlockUnderTypes.modernAndesite.addOreDict("stoneAndesite", "stoneAndesitePolished", "stoneAndesiteBricks", "stoneAndesiteChiseled");
+        CropsNHBlockUnderTypes.modernDiorite.addOreDict("stoneDiorite", "stoneDioritePolished", "stoneDioriteBricks", "stoneDioriteChiseled");
+        CropsNHBlockUnderTypes.modernGranite.addOreDict("stoneGranite", "stoneGranitePolished", "stoneGraniteBricks", "stoneGraniteChiseled");
         // Et Futurum Stone Lilies
         if (ModUtils.EtFuturumRequiem.isModLoaded()) {
             CropsNHBlockUnderTypes.tuff.addBlock(new BlockWithMeta(ModUtils.EtFuturumRequiem.getBlock("tuff")));
@@ -122,13 +124,13 @@ public class BlockUnderRequirementLoader {
             CropsNHBlockUnderTypes.aluminiumBauxite.addBlock(
                 new BlockWithMeta(ModUtils.Chisel.getBlock("aluminumblock"))
             );
-            CropsNHBlockUnderTypes.botaniaAndesite.addBlock(
+            CropsNHBlockUnderTypes.modernAndesite.addBlock(
                 new BlockWithMeta(ModUtils.Chisel.getBlock("andesite"))
             );
-            CropsNHBlockUnderTypes.botaniaDiorite.addBlock(
+            CropsNHBlockUnderTypes.modernDiorite.addBlock(
                 new BlockWithMeta(ModUtils.Chisel.getBlock("diorite"))
             );
-            CropsNHBlockUnderTypes.botaniaGranite.addBlock(
+            CropsNHBlockUnderTypes.modernGranite.addBlock(
                 new BlockWithMeta(ModUtils.Chisel.getBlock("granite"))
             );
             CropsNHBlockUnderTypes.clay.addBlock(
@@ -268,6 +270,23 @@ public class BlockUnderRequirementLoader {
                 new BlockWithMeta(ModUtils.EtFuturumRequiem.getBlock("smooth_red_sandstone")),
                 new BlockWithMeta(ModUtils.EtFuturumRequiem.getBlock("red_sandstone"))
             );
+
+            // gotta check if the block was registered since it's a config.
+            Block efrStone = GameRegistry.findBlock(ModUtils.EtFuturumRequiem.ID, "stone");
+            if (efrStone != null) {
+                CropsNHBlockUnderTypes.modernGranite.addBlock(
+                    new BlockWithMeta(efrStone, 1),
+                    new BlockWithMeta(efrStone, 2)
+                );
+                CropsNHBlockUnderTypes.modernDiorite.addBlock(
+                    new BlockWithMeta(efrStone, 3),
+                    new BlockWithMeta(efrStone, 4)
+                );
+                CropsNHBlockUnderTypes.modernAndesite.addBlock(
+                    new BlockWithMeta(efrStone, 5),
+                    new BlockWithMeta(efrStone, 6)
+                );
+            }
         }
         if (ModUtils.ExtraUtilities.isModLoaded()) {
             CropsNHBlockUnderTypes.stone.addBlock(

--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/CropLoader.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/CropLoader.java
@@ -2,6 +2,7 @@ package com.gtnewhorizon.cropsnh.loaders;
 
 import java.awt.Color;
 
+import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -148,11 +149,11 @@ import com.gtnewhorizon.cropsnh.crops.stoneilies.CropRedGraniteLily;
 import com.gtnewhorizon.cropsnh.crops.stoneilies.CropSandLily;
 import com.gtnewhorizon.cropsnh.crops.stoneilies.CropSoulSandLily;
 import com.gtnewhorizon.cropsnh.crops.stoneilies.CropStoneLily;
-import com.gtnewhorizon.cropsnh.crops.stoneilies.botania.CropAndesiteLily;
-import com.gtnewhorizon.cropsnh.crops.stoneilies.botania.CropDioriteLily;
-import com.gtnewhorizon.cropsnh.crops.stoneilies.botania.CropGraniteLily;
 import com.gtnewhorizon.cropsnh.crops.stoneilies.etfuturum.CropDeepslateLily;
 import com.gtnewhorizon.cropsnh.crops.stoneilies.etfuturum.CropTuffLily;
+import com.gtnewhorizon.cropsnh.crops.stoneilies.modern.CropAndesiteLily;
+import com.gtnewhorizon.cropsnh.crops.stoneilies.modern.CropDioriteLily;
+import com.gtnewhorizon.cropsnh.crops.stoneilies.modern.CropGraniteLily;
 import com.gtnewhorizon.cropsnh.crops.thaumcraft.CropCinderpearl;
 import com.gtnewhorizon.cropsnh.crops.thaumcraft.CropManaBean;
 import com.gtnewhorizon.cropsnh.crops.thaumcraft.CropPrimordialBerry;
@@ -188,6 +189,7 @@ import com.gtnewhorizon.cropsnh.farming.registries.CropRegistry;
 import com.gtnewhorizon.cropsnh.utility.CropsNHUtils;
 import com.gtnewhorizon.cropsnh.utility.ModUtils;
 
+import cpw.mods.fml.common.registry.GameRegistry;
 import gregtech.api.enums.ItemList;
 
 public class CropLoader {
@@ -491,8 +493,9 @@ public class CropLoader {
     }
 
     private static void registerStoneLilies() {
-        if (ModUtils.Botania.isModLoaded() || ModUtils.EtFuturumRequiem.isModLoaded()
-            || ModUtils.Chisel.isModLoaded()) {
+        // gotta check if the block was registered since it's a config.
+        Block efrStone = GameRegistry.findBlock(ModUtils.EtFuturumRequiem.ID, "stone");
+        if (ModUtils.Botania.isModLoaded() || ModUtils.Chisel.isModLoaded() || efrStone != null) {
             CropRegistry.instance.register(CropsNHCrops.AndesiteLily = new CropAndesiteLily());
             CropRegistry.instance.register(CropsNHCrops.DioriteLily = new CropDioriteLily());
             CropRegistry.instance.register(CropsNHCrops.GraniteLily = new CropGraniteLily());

--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/CropLoader.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/CropLoader.java
@@ -491,7 +491,8 @@ public class CropLoader {
     }
 
     private static void registerStoneLilies() {
-        if (ModUtils.Botania.isModLoaded()) {
+        if (ModUtils.Botania.isModLoaded() || ModUtils.EtFuturumRequiem.isModLoaded()
+            || ModUtils.Chisel.isModLoaded()) {
             CropRegistry.instance.register(CropsNHCrops.AndesiteLily = new CropAndesiteLily());
             CropRegistry.instance.register(CropsNHCrops.DioriteLily = new CropDioriteLily());
             CropRegistry.instance.register(CropsNHCrops.GraniteLily = new CropGraniteLily());

--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/MutationLoader.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/MutationLoader.java
@@ -262,6 +262,7 @@ import static com.gtnewhorizon.cropsnh.api.CropsNHMutationPools.aWood;
 import static com.gtnewhorizon.cropsnh.api.CropsNHMutationPools.aYellow;
 import static com.gtnewhorizon.cropsnh.api.CropsNHMutationPools.aZombie;
 
+import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 
@@ -270,6 +271,7 @@ import com.gtnewhorizon.cropsnh.farming.registries.MutationRegistry;
 import com.gtnewhorizon.cropsnh.farming.requirements.breeding.MachineBreedingCatalystRequirement;
 import com.gtnewhorizon.cropsnh.utility.ModUtils;
 
+import cpw.mods.fml.common.registry.GameRegistry;
 import gregtech.api.enums.Mods;
 
 public class MutationLoader {
@@ -765,7 +767,9 @@ public class MutationLoader {
         // endregion ore berries
 
         // region stone lilies
-        if (ModUtils.Botania.isModLoaded() || ModUtils.EtFuturumRequiem.isModLoaded() || ModUtils.Chisel.isModLoaded()) {
+        // gotta check if the block was registered since it's a config.
+        Block efrStone = GameRegistry.findBlock(ModUtils.EtFuturumRequiem.ID, "stone");
+        if (ModUtils.Botania.isModLoaded() || ModUtils.Chisel.isModLoaded() || efrStone != null) {
             new CropMutation(AndesiteLily, StoneLily, ClayLily)
                 .addToMutationPools(aGray, aStone, aMetal)
                 .register();

--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/MutationLoader.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/MutationLoader.java
@@ -779,14 +779,15 @@ public class MutationLoader {
             new CropMutation(GraniteLily, BlackGraniteLily, RedGraniteLily)
                 .addToMutationPools(aRed, aStone, aFire)
                 .register();
-        }
-        if (ModUtils.EtFuturumRequiem.isModLoaded()) {
-            new CropMutation(TuffLily, BlackGraniteLily, AndesiteLily)
-                .addToMutationPools(aGray, aStone, aDark)
-                .register();
-            new CropMutation(DeepslateLily,TuffLily, BlackGraniteLily)
-                .addToMutationPools(aBlack, aStone, aDark)
-                .register();
+
+            if (ModUtils.EtFuturumRequiem.isModLoaded()) {
+                new CropMutation(TuffLily, BlackGraniteLily, AndesiteLily)
+                    .addToMutationPools(aGray, aStone, aDark)
+                    .register();
+                new CropMutation(DeepslateLily,TuffLily, BlackGraniteLily)
+                    .addToMutationPools(aBlack, aStone, aDark)
+                    .register();
+            }
         }
         new CropMutation(BasaltLily, StoneLily, InkBloom)
             .addToMutationPools(aBlack, aStone, aDark)

--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/MutationLoader.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/MutationLoader.java
@@ -765,7 +765,7 @@ public class MutationLoader {
         // endregion ore berries
 
         // region stone lilies
-        if (ModUtils.Botania.isModLoaded()) {
+        if (ModUtils.Botania.isModLoaded() || ModUtils.EtFuturumRequiem.isModLoaded() || ModUtils.Chisel.isModLoaded()) {
             new CropMutation(AndesiteLily, StoneLily, ClayLily)
                 .addToMutationPools(aGray, aStone, aMetal)
                 .register();
@@ -777,7 +777,7 @@ public class MutationLoader {
                 .register();
         }
         if (ModUtils.EtFuturumRequiem.isModLoaded()) {
-            new CropMutation(TuffLily, BlackGraniteLily, StoneLily)
+            new CropMutation(TuffLily, BlackGraniteLily, AndesiteLily)
                 .addToMutationPools(aGray, aStone, aDark)
                 .register();
             new CropMutation(DeepslateLily,TuffLily, BlackGraniteLily)

--- a/src/main/resources/assets/cropsnh/lang/en_US.lang
+++ b/src/main/resources/assets/cropsnh/lang/en_US.lang
@@ -684,7 +684,7 @@ cropsnh_crops.thauminiteOreBerry=Thauminite Oreberry
 cropsnh_crops.thaumiumOreBerry=Thaumium Oreberry
 cropsnh_crops.tinOreBerry=Tin Oreberry
 cropsnh_crops.voidOreBerry=Void Metal Oreberry
-# Stone Lily Crop Names (Botania)
+# Stone Lily Crop Names (Modern)
 cropsnh_crops.andesiteLily=Andesite Lily
 cropsnh_crops.dioriteLily=Diorite Lily
 cropsnh_crops.graniteLily=Granite Lily
@@ -741,10 +741,10 @@ cropsnh_growthReq.blockUnder.basalt=Needs a block of basalt under it to grow
 # Et EtFuturum Stone Lily Requirements
 cropsnh_growthReq.blockUnder.deepslate=Needs a block of deepslate under it to grow
 cropsnh_growthReq.blockUnder.tuff=Needs a block of tuff under it to grow
-# Botania Stone Lily Growth Requirements
-cropsnh_growthReq.blockUnder.botaniaAndesite=Needs a block of andesite under it to grow
-cropsnh_growthReq.blockUnder.botaniaDiorite=Needs a block of diorite under it to grow
-cropsnh_growthReq.blockUnder.botaniaGranite=Needs a block of granite under it to grow
+# Modern Stone Lily Growth Requirements
+cropsnh_growthReq.blockUnder.modernAndesite=Needs a block of andesite under it to grow
+cropsnh_growthReq.blockUnder.modernDiorite=Needs a block of diorite under it to grow
+cropsnh_growthReq.blockUnder.modernGranite=Needs a block of granite under it to grow
 # Vanilla Ore Growth Requirements
 cropsnh_growthReq.blockUnder.coal=Needs a block of coal under it to grow
 cropsnh_growthReq.blockUnder.iron=Needs a block of iron under it to grow


### PR DESCRIPTION
It was colliding with ferrofern. For early crops like these, I'd rather not have collisions like these.

For later crops, I'm mostly fine with this kind of collision, given the breeder will keep checking other valid parent matches if a mutation fails due to some requirement failing.

It also refactors the "botania" lilies to "modern" lilies, and tunes up the list of mods/conditions for them to be loaded by correctly identifying all the various backports we have for the modern stones.

tested using daily 522