### PR TITLE
Switch output mode to output items via mOutputItems

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
@@ -1153,7 +1153,10 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
             this.setBlockUnderStack(blockUnderStack.stackSize <= 0 ? null : blockUnderStack);
         }
         // eject seeds and blocks
-        ejectionHelper.commit();
+        for (ItemStack stack : simulated) {
+            stack.stackSize = maxParallels;
+        }
+        this.mOutputItems = simulated.toArray(new ItemStack[0]);
 
         // notify success
         this.mMaxProgresstime = 5;


### PR DESCRIPTION
There definitely seems to be a bug in the ejection helper that causes it to output more items than it should when it's told to prevent output voiding.

Resolves https://github.com/GTNewHorizons/Dupes-Exploits-GTNH/issues/313

https://github.com/user-attachments/assets/4465a7cb-a9bf-47e6-934f-b6f7d35ed37c

