### PR TITLE
Breeder/Generator Bug Fixes and QoL improvements

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -57,6 +57,7 @@ dependencies {
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Tainted-Magic:7.7.7-GTNH:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:WitcheryExtras:1.4.15:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:WitchingGadgets:1.8.45-GTNH:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:ThaumicTinkerer:2.12.22:dev") { transitive = false }
     // // required in order to have pam
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Chisel:2.17.26-GTNH:dev") { transitive = false }
     // // mod specific crops and soils

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/singleblock/MTECropBreeder.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/singleblock/MTECropBreeder.java
@@ -308,7 +308,7 @@ public class MTECropBreeder extends MTEBasicMachine {
         if (GTUtility.isStackInvalid(aStack) || !(aStack.getItem() instanceof ItemGenericSeed)) return null;
         // check that it's a crop card and that it can cross.
         ICropCard cc = CropRegistry.instance.get(aStack);
-        if (cc == null || cc.getCrossingThreshold() < 0.0f) return null;
+        if (cc == null) return null;
         // fail if the crop isn't analyzed
         SeedStats stats = SeedStats.getStatsFromStack(aStack);
         if (stats == null || !stats.isAnalyzed()) return null;

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/singleblock/MTECropBreeder.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/singleblock/MTECropBreeder.java
@@ -86,6 +86,33 @@ public class MTECropBreeder extends MTEBasicMachine {
         ALLOWED_LIQUID_FERTILIZER.putIfAbsent(CropsNHFluids.enrichedFertilizer, 1.0f);
     }
 
+    private static String[] getToolTip(int aTier) {
+        List<String> tt = new ArrayList<>();
+        tt.add(CropsNHUtils.getMachineTypeText("cropBreeder"));
+        tt.add(StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.cropBreeder.0"));
+        tt.add(
+            StatCollector.translateToLocalFormatted(
+                Reference.MOD_ID + "_tooltip.cropBreeder.1",
+                TooltipHelper.fluidText(FERTILIZER_PER_TIER)));
+        tt.add(
+            StatCollector.translateToLocalFormatted(
+                Reference.MOD_ID + "_tooltip.cropBreeder.2",
+                TooltipHelper.fluidText(FERTILIZER_PER_STAT)));
+        tt.add(StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.cropBreeder.3"));
+        tt.add(
+            StatCollector.translateToLocalFormatted(
+                Reference.MOD_ID + "_tooltip.cropBreeder.4",
+                formatNumber(getOutputChance(aTier))));
+        tt.add(
+            StatCollector.translateToLocalFormatted(
+                Reference.MOD_ID + "_tooltip.cropBreeder.5",
+                TooltipHelper.fluidText(getCustomFluidCapacity(aTier))));
+        if (aTier <= VoltageIndex.MV) {
+            tt.add(StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.cropBreeder.mv_warn"));
+        }
+        return tt.toArray(new String[0]);
+    }
+
     public MTECropBreeder(int aID, int aTier) {
         super(
             aID,
@@ -93,22 +120,7 @@ public class MTECropBreeder extends MTEBasicMachine {
             StatCollector.translateToLocal("cropsnh_tooltip.cropBreeder.name." + aTier),
             aTier,
             AMPERAGE,
-            new String[] {
-                // spotless:off
-                CropsNHUtils.getMachineTypeText("cropBreeder"),
-                StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.cropBreeder.0"),
-                StatCollector.translateToLocalFormatted(Reference.MOD_ID + "_tooltip.cropBreeder.1",
-                    TooltipHelper.fluidText(FERTILIZER_PER_TIER)
-                ),
-                StatCollector.translateToLocalFormatted(Reference.MOD_ID + "_tooltip.cropBreeder.2",
-                    TooltipHelper.fluidText(FERTILIZER_PER_STAT)
-                ),
-                StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.cropBreeder.3"),
-                StatCollector.translateToLocalFormatted(Reference.MOD_ID + "_tooltip.cropBreeder.4",
-                    formatNumber(getOutputChance(aTier))
-                )
-                // spotless:on
-            },
+            getToolTip(aTier),
             getInputSlotCount(aTier),
             OUTPUT_SLOT_COUNT,
             TextureFactory.of(
@@ -335,7 +347,12 @@ public class MTECropBreeder extends MTEBasicMachine {
 
     @Override
     public int getCapacity() {
-        return getCapacityForTier(mTier) / 5;
+        // iv and below gets low capacity, iv and above get more to allow for higher speed processing at higher tier.
+        return getCustomFluidCapacity(this.mTier);
+    }
+
+    public static int getCustomFluidCapacity(int aTier) {
+        return aTier < VoltageIndex.IV ? getCapacityForTier(aTier) / 5 : getCapacityForTier(aTier);
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/singleblock/MTESeedGenerator.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/singleblock/MTESeedGenerator.java
@@ -185,6 +185,11 @@ public class MTESeedGenerator extends MTEBasicMachine {
             ItemStack tStack = this.getInputAt(i);
             tSeedData = CropsNHUtils.getAnalyzedSeedData(tStack);
             if (tSeedData != null) {
+                // don't replicate seeds that require the synthesizer in the seed generator
+                if (tSeedData.getCrop()
+                    .getCrossingThreshold() < 0.0f) {
+                    continue;
+                }
                 ISeedStats tStats = tSeedData.getStats();
                 // check if we have enough fluid to duplicate the seed.
                 tFluidToConsume = getFluidAmount(

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/singleblock/MTESeedGenerator.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/singleblock/MTESeedGenerator.java
@@ -18,7 +18,9 @@ import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_TOP_SCANNER_ACTIVE_
 import static gregtech.api.enums.Textures.BlockIcons.OVERLAY_TOP_SCANNER_GLOW;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
@@ -39,6 +41,7 @@ import com.gtnewhorizon.cropsnh.utility.CropsNHUtils;
 
 import gregtech.api.enums.SoundResource;
 import gregtech.api.enums.TierEU;
+import gregtech.api.enums.VoltageIndex;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
@@ -66,6 +69,25 @@ public class MTESeedGenerator extends MTEBasicMachine {
         ALLOWED_LIQUID_FERTILIZER.putIfAbsent(CropsNHFluids.enrichedFertilizer, 1.0f);
     }
 
+    private static String[] getToolTip(int aTier) {
+        List<String> tt = new ArrayList<>();
+        tt.add(CropsNHUtils.getMachineTypeText("seedGenerator"));
+        tt.add(StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.seedGenerator.0"));
+        tt.add(
+            StatCollector.translateToLocalFormatted(
+                Reference.MOD_ID + "_tooltip.seedGenerator.1",
+                TooltipHelper.fluidText(FERTILIZER_PER_STAT)));
+        tt.add(StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.seedGenerator.2"));
+        tt.add(
+            StatCollector.translateToLocalFormatted(
+                Reference.MOD_ID + "_tooltip.seedGenerator.3",
+                TooltipHelper.fluidText(getCustomFluidCapacity(aTier))));
+        if (aTier <= VoltageIndex.MV) {
+            tt.add(StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.seedGenerator.mv_warn"));
+        }
+        return tt.toArray(new String[0]);
+    }
+
     public MTESeedGenerator(int aID, int aTier) {
         super(
             aID,
@@ -73,16 +95,7 @@ public class MTESeedGenerator extends MTEBasicMachine {
             StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.seedGenerator.name." + aTier),
             aTier,
             AMPERAGE,
-            new String[] {
-                // spotless:off
-                CropsNHUtils.getMachineTypeText("seedGenerator"),
-                StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.seedGenerator.0"),
-                StatCollector.translateToLocalFormatted(Reference.MOD_ID + "_tooltip.seedGenerator.1",
-                    TooltipHelper.fluidText(FERTILIZER_PER_STAT)
-                ),
-                StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.seedGenerator.2"),
-                // spotless:on
-            },
+            getToolTip(aTier),
             INPUT_SLOT_COUNT,
             OUTPUT_SLOT_COUNT,
             TextureFactory.of(
@@ -264,7 +277,12 @@ public class MTESeedGenerator extends MTEBasicMachine {
 
     @Override
     public int getCapacity() {
-        return getCapacityForTier(mTier) / 10;
+        // iv and below gets low capacity, iv and above get more to allow for higher speed processing at higher tier.
+        return getCustomFluidCapacity(this.mTier);
+    }
+
+    public static int getCustomFluidCapacity(int aTier) {
+        return aTier < VoltageIndex.IV ? getCapacityForTier(aTier) / 10 : getCapacityForTier(aTier);
     }
 
     @Override

--- a/src/main/resources/assets/cropsnh/lang/en_US.lang
+++ b/src/main/resources/assets/cropsnh/lang/en_US.lang
@@ -164,12 +164,12 @@ cropsnh.recipes.cropBreeder=Crop Breeder
 cropsnh_tooltip.cropBreeder.0=Breeds crops deterministically
 cropsnh_tooltip.cropBreeder.1=Needs %1$s of §aenriched fertilizer§7 per §ctier§7 of the output seed
 cropsnh_tooltip.cropBreeder.2=Needs %1$s of §aenriched fertilizer§7 per §cstat point§7 of the output seed
-cropsnh_tooltip.cropBreeder.3=The stats of the output seed will be the average of the parents
+cropsnh_tooltip.cropBreeder.3=The stats of the output seed will be the average of the parents'
 cropsnh_tooltip.cropBreeder.4=%1$s%% success chance
 cropsnh_tooltip.cropBreeder.5=Stores %1$s of fluid
 cropsnh_tooltip.cropBreeder.mv_warn=§cCannot breed high-stat seeds§7
 cropsnh_nei.cropBreeder.tooltip.fluidCost=cost = OutputTier * %1$s + (growth + gain + resistance) * %2$s
-cropsnh_nei.cropBreeder.tooltip.outputStats=The resulting stats will be an average of the parents
+cropsnh_nei.cropBreeder.tooltip.outputStats=The resulting stats will be an average of the parents'
 cropsnh_nei.cropBreeder.tooltip.successChance=Success chance depends on the tier of the machine
 cropsnh_tooltip.cropBreeder.name.1=Basic Crop Breeder
 cropsnh_tooltip.cropBreeder.name.2=Advanced Crop Breeder

--- a/src/main/resources/assets/cropsnh/lang/en_US.lang
+++ b/src/main/resources/assets/cropsnh/lang/en_US.lang
@@ -166,6 +166,8 @@ cropsnh_tooltip.cropBreeder.1=Needs %1$s of §aenriched fertilizer§7 per §ctie
 cropsnh_tooltip.cropBreeder.2=Needs %1$s of §aenriched fertilizer§7 per §cstat point§7 of the output seed
 cropsnh_tooltip.cropBreeder.3=The stats of the output seed will be the average of the parents
 cropsnh_tooltip.cropBreeder.4=%1$s%% success chance
+cropsnh_tooltip.cropBreeder.5=Stores %1$s of fluid
+cropsnh_tooltip.cropBreeder.mv_warn=§cCannot breed high-stat seeds§7
 cropsnh_nei.cropBreeder.tooltip.fluidCost=cost = OutputTier * %1$s + (growth + gain + resistance) * %2$s
 cropsnh_nei.cropBreeder.tooltip.outputStats=The resulting stats will be an average of the parents
 cropsnh_nei.cropBreeder.tooltip.successChance=Success chance depends on the tier of the machine
@@ -224,6 +226,8 @@ cropsnh.recipes.seedGenerator=Seed Generator
 cropsnh_tooltip.seedGenerator.0=Generates more seeds from an existing seed
 cropsnh_tooltip.seedGenerator.1=Needs %1$s of §aenriched fertilizer§7 per §cstat point§7 on the seed
 cropsnh_tooltip.seedGenerator.2=Not all crops can be replicated in this machine
+cropsnh_tooltip.seedGenerator.3=Stores %1$s of fluid
+cropsnh_tooltip.seedGenerator.mv_warn=§cCannot replicate high-stat seeds§7
 cropsnh_nei.seedGenerator.tooltip.fluidCost=cost = %1$s * (growth + gain + resistance)
 cropsnh_tooltip.seedGenerator.name.1=Basic Seed Generator
 cropsnh_tooltip.seedGenerator.name.2=Advanced Seed Generator


### PR DESCRIPTION
This PR fixes 2 important bugs, adds much-needed tooltips, and improves the fluid capacity of IV+ Seed Generators and Crop Breeders to support high-speed crop replication/breeding, since their low capacity made high-speed recipes run quite slowly.

- Resolves #144 
- Fixes a bug that allowed synthesizer-only crops to be replicated in the seed generator.
- Added fluid capacity to the tooltips of the Seed Generators and Crop Breeders.
- Added a warning to the tooltip of MV and lower Seed Generators and Crop Breeders to tell players about the low capacity preventing the replication/breeding of high-stat seeds.
- IV and higher Seed Generators and Crop Breeders will default to the usual fluid capacity for their relevant tiers (currently 256KL)

## Breeder fix

https://github.com/user-attachments/assets/76d7c0cc-7f5c-4bb9-af11-252c0284f0ca

## Seed generator fix

https://github.com/user-attachments/assets/5338e66a-5423-48a6-a842-4662a0d407eb

Still works in a synthesizer

https://github.com/user-attachments/assets/f4d549ce-9be9-4e51-90ea-48665bd8e04e

## tooltips and capacity improvements
crop breeder
<img width="1089" height="396" alt="image" src="https://github.com/user-attachments/assets/204b04cc-a603-4285-9cbc-d4ec8d75f6dc" />
<img width="1044" height="381" alt="image" src="https://github.com/user-attachments/assets/9b45be43-2c28-44fd-b0e5-de7d8e78b296" />
<img width="1036" height="413" alt="image" src="https://github.com/user-attachments/assets/f56f8c44-727b-4909-afc7-2aa31b69eab6" />

seed generator
<img width="933" height="352" alt="image" src="https://github.com/user-attachments/assets/ec6ff40f-f65c-4c08-8069-c394efdea275" />
<img width="929" height="317" alt="image" src="https://github.com/user-attachments/assets/cddeb3af-2915-4475-a29c-8032b38b3969" />
<img width="933" height="350" alt="image" src="https://github.com/user-attachments/assets/99e2752c-0b5f-49ff-a879-5b437bac7741" />
