### PR TITLE
Fix IF only crops being sometimes harvestable

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
@@ -506,10 +506,16 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
 
     @Override
     public boolean canHarvest() {
-        return !this.worldObj.isRemote && this.hasCrop()
+        if (!this.worldObj.isRemote && this.hasCrop()
             && !this.hasWeed()
             && this.isMature()
-            && this.failedChecks == null;
+            && this.failedChecks == null) {
+            for (IGrowthRequirement req : seed.getCrop()
+                .getGrowthRequirements()) {
+                if (req instanceof MachineOnlyGrowthRequirement) return false;
+            }
+            return true;
+        }
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
@@ -516,6 +516,7 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
             }
             return true;
         }
+        return false;
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
@@ -716,6 +716,10 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
         this.fertilizerStorage = tag.hasKey(Names.NBT.fertilizer, NBT.TAG_INT) ? tag.getInteger(Names.NBT.fertilizer)
             : 0;
         this.weedEXStorage = tag.hasKey(Names.NBT.weedEX, NBT.TAG_INT) ? tag.getInteger(Names.NBT.weedEX) : 0;
+
+        if (CropsNHUtils.isServer() && this.worldObj != null) {
+            this.areGrowthRequirementsMet();
+        }
         this.isDirty = true;
     }
 
@@ -1104,7 +1108,9 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
         if (!this.hasCrop()) return false;
         this.seed.getCrop()
             .onFirstTick(this, this.worldObj, this.xCoord, this.yCoord, this.zCoord);
-
+        // run a growth req check on the first tick since dislocator focus is a thing.
+        this.areGrowthRequirementsMet();
+        // detect invalid soils
         if (this.hasSoilChanged && !this.isValidSoilForCrop(this.seed.getCrop())) {
             boolean ret = this.onInvalidSoilDetected();
             this.hasSoilChanged = false;
@@ -1258,6 +1264,8 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
                 if (!player.capabilities.isCreativeMode) {
                     heldItem.stackSize--;
                 }
+                // run a check to see if the growth reqs are met
+                this.areGrowthRequirementsMet();
                 return true;
             } else if (result == SeedPlantingResult.WRONG_SOIL) {
                 if (player instanceof EntityPlayerMP mpPlayer) {

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
@@ -52,6 +52,7 @@ import com.gtnewhorizon.cropsnh.farming.registries.CropRegistry;
 import com.gtnewhorizon.cropsnh.farming.registries.FertilizerRegistry;
 import com.gtnewhorizon.cropsnh.farming.registries.MutationRegistry;
 import com.gtnewhorizon.cropsnh.farming.registries.SoilTramplingResistanceRegistry;
+import com.gtnewhorizon.cropsnh.farming.requirements.growth.MachineOnlyGrowthRequirement;
 import com.gtnewhorizon.cropsnh.handler.ConfigurationHandler;
 import com.gtnewhorizon.cropsnh.init.CropsNHBlocks;
 import com.gtnewhorizon.cropsnh.items.ItemGenericSeed;
@@ -510,9 +511,6 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
             && this.isMature()
             && this.failedChecks == null;
     }
-
-    static double test = 0;
-    static int printCounter = 0;
 
     @Override
     public ArrayList<ItemStack> harvest(double dropMultiplier) {


### PR DESCRIPTION
This PR fixes an issue that allowed mature IF-only crops to be harvested before they hit their first growth tick after reloading the world or being moved using a dislocation focus.