### PR TITLE
Add FindIt support to ignore stats on seeds

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,6 +9,7 @@ dependencies {
     devOnlyNonPublishable("com.github.GTNewHorizons:ForestryMC:4.11.23:dev") { transitive = false }
     devOnlyNonPublishable("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
     devOnlyNonPublishable('com.github.GTNewHorizons:Backhand:1.8.10:dev') { transitive = false }
+    compile('com.github.GTNewHorizons:FindIt:1.4.3:dev')
 
 
     // // debugging tools

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,7 +9,7 @@ dependencies {
     devOnlyNonPublishable("com.github.GTNewHorizons:ForestryMC:4.11.23:dev") { transitive = false }
     devOnlyNonPublishable("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
     devOnlyNonPublishable('com.github.GTNewHorizons:Backhand:1.8.10:dev') { transitive = false }
-    compile('com.github.GTNewHorizons:FindIt:1.4.3:dev')
+    compileOnly('com.github.GTNewHorizons:FindIt:1.4.3:dev')
 
 
     // // debugging tools

--- a/src/main/java/com/gtnewhorizon/cropsnh/CropsNH.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/CropsNH.java
@@ -3,6 +3,7 @@ package com.gtnewhorizon.cropsnh;
 import com.gtnewhorizon.cropsnh.compatibility.StructureLib.StructureLibCompatHandler;
 import com.gtnewhorizon.cropsnh.compatibility.TiC.TiCCompatHandler;
 import com.gtnewhorizon.cropsnh.compatibility.extrautils.ExUWateringCanHandler;
+import com.gtnewhorizon.cropsnh.compatibility.findit.CropsNHHandler;
 import com.gtnewhorizon.cropsnh.compatibility.forestry.ForestryCompatHandler;
 import com.gtnewhorizon.cropsnh.compatibility.waila.WailaRegistry;
 import com.gtnewhorizon.cropsnh.farming.registries.MutationRegistry;
@@ -28,8 +29,10 @@ import com.gtnewhorizon.cropsnh.tileentity.singleblock.MTECropBreeder;
 import com.gtnewhorizon.cropsnh.tileentity.singleblock.MTESeedGenerator;
 import com.gtnewhorizon.cropsnh.utility.LogHelper;
 import com.gtnewhorizon.cropsnh.utility.ModUtils;
+import com.gtnh.findit.FindIt;
 
 import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.SidedProxy;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
@@ -83,6 +86,9 @@ public class CropsNH {
         CropsNHItems.preInit();
         CropsNHFluids.preInit();
         OreDictLoader.preInit();
+        if (Loader.isModLoaded("findit")) {
+            FindIt.INSTANCE.pluginsList.add(new CropsNHHandler());
+        }
         LogHelper.debug("Pre-Initialization Complete");
     }
 

--- a/src/main/java/com/gtnewhorizon/cropsnh/compatibility/findit/CropsNHHandler.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/compatibility/findit/CropsNHHandler.java
@@ -1,0 +1,40 @@
+package com.gtnewhorizon.cropsnh.compatibility.findit;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+
+import com.gtnewhorizon.cropsnh.api.ICropCard;
+import com.gtnewhorizon.cropsnh.farming.registries.CropRegistry;
+import com.gtnh.findit.IStackFilter;
+import com.gtnh.findit.service.itemfinder.FindItemRequest;
+
+public class CropsNHHandler implements IStackFilter.IStackFilterProvider {
+
+    private static class CropStackFilter implements IStackFilter {
+
+        String id;
+
+        public CropStackFilter(String id) {
+            this.id = id;
+        }
+
+        @Override
+        public boolean matches(FindItemRequest request) {
+            ItemStack stack = request.getStackToFind();
+            ICropCard crop = CropRegistry.instance.get(stack);
+            return crop != null && id.equals(crop.getId());
+        }
+    }
+
+    @Override
+    public IStackFilter getFilter(EntityPlayer player, TileEntity tileEntity) {
+        return null;
+    }
+
+    @Override
+    public IStackFilter getFilter(EntityPlayer player, ItemStack stack) {
+        ICropCard crop = CropRegistry.instance.get(stack);
+        return crop == null ? null : new CropStackFilter(crop.getId());
+    }
+}


### PR DESCRIPTION
Using FindIt on a seed will now find any seed with the same ID. Stats are ignored.

https://github.com/user-attachments/assets/63d5f8c1-d2d2-4e6c-82e6-0d7d49da950a

