### PR TITLE
re-add missing oil comb extraction recipe

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
@@ -61,6 +61,9 @@ import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTRecipeBuilder;
 import gregtech.api.util.GTRecipeConstants;
 import gregtech.api.util.GTUtility;
+import gregtech.common.items.CombType;
+import gregtech.common.items.DropType;
+import gregtech.loaders.misc.GTBees;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 import gtPlusPlus.xmod.thermalfoundation.fluid.TFFluids;
 import gtnhlanth.api.recipe.LanthanidesRecipeMaps;
@@ -715,6 +718,15 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
     }
 
     private static void addOilBerryRecipes() {
+        // oil comb centrifuging to oil berries
+        if (ModUtils.Forestry.isModLoaded()) {
+            GTBees.combs.addCentrifugeToItemStack(
+                CombType.OIL,
+                new ItemStack[] { CropsNHItemList.oilBerry.get(6), GTBees.drop.getStackForType(DropType.OIL),
+                    ItemList.FR_Wax.get(1) },
+                new int[] { 100 * 100, 100 * 100, 50 * 100 },
+                Voltage.ULV);
+        }
 
         // fluid extraction
         lvRecipe(1, 00).itemInputs(MaterialLeafLoader.oilBerry.get(1))


### PR DESCRIPTION
This PR re-adds the oil comb -> oil berry extraction recipe since i forgot to transfer it over during the integration period of the rework: https://github.com/GTNewHorizons/GT5-Unofficial/pull/5652/changes#diff-50467771e059b3b8adb92e3ea968f19e856b643922a314402a90f534eec59237

All recipe values should remain unchanged.

<img width="519" height="508" alt="image" src="https://github.com/user-attachments/assets/5b558564-926b-44b0-8ffc-e7a492021b63" />