### PR TITLE
Add removal noise for cross crop

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/api/ICropStickTile.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/api/ICropStickTile.java
@@ -66,6 +66,11 @@ public interface ICropStickTile {
     void setCrossCrop(boolean status);
 
     /**
+     * Plays the cross-crop placement and removal noise.
+     */
+    void playCrossCropSound();
+
+    /**
      * @return if a plant can be planted here, meaning the crop is empty and is not a cross crop
      */
     boolean canPlantSeed();

--- a/src/main/java/com/gtnewhorizon/cropsnh/items/blocks/ItemCropSticks.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/items/blocks/ItemCropSticks.java
@@ -53,15 +53,16 @@ public class ItemCropSticks extends ItemBlockCropsNH implements ICropRightClickH
         if (isPlacingCross && world.getTileEntity(x, y + 1, z) instanceof ICropStickTile crop) {
             crop.setCrossCrop(true);
             world.markBlockForUpdate(x, y + 1, z);
-        } else {
-            world.playSoundEffect(
-                ((float) x + 0.5F),
-                ((float) y + 1.5F),
-                ((float) z + 0.5F),
-                Blocks.planks.stepSound.func_150496_b(),
-                (Blocks.planks.stepSound.getVolume() + 1.0F) / 2.0F,
-                Blocks.planks.stepSound.getPitch() * 0.8F);
         }
+
+        // play placement sound
+        world.playSoundEffect(
+            ((float) x + 0.5F),
+            ((float) y + 1.5F),
+            ((float) z + 0.5F),
+            Blocks.planks.stepSound.func_150496_b(),
+            (Blocks.planks.stepSound.getVolume() + 1.0F) / 2.0F,
+            Blocks.planks.stepSound.getPitch() * 0.8F);
         return true;
     }
 
@@ -72,6 +73,7 @@ public class ItemCropSticks extends ItemBlockCropsNH implements ICropRightClickH
         if (heldItem == null || heldItem.stackSize < 1 || !te.canUpgrade()) return false;
         // upgrade the crop stick to a cross
         te.setCrossCrop(true);
+        te.playCrossCropSound();
         // consume items if necessary
         heldItem.stackSize -= player.capabilities.isCreativeMode ? 0 : 1;
         return true;

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
@@ -478,17 +478,18 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
             this.clear();
             this.isCrossCrop = status;
             this.isDirty = true;
-            if (!worldObj.isRemote && isCrossCrop) {
-                // play a plank noise
-                worldObj.playSoundEffect(
-                    ((double) xCoord + 0.5d),
-                    ((double) yCoord + 0.5d),
-                    ((double) zCoord + 0.5d),
-                    Blocks.planks.stepSound.func_150496_b(),
-                    (Blocks.planks.stepSound.getVolume() + 1.0f) / 2.0f,
-                    Blocks.planks.stepSound.getPitch() * 0.8f);
-            }
         }
+    }
+
+    @Override
+    public void playCrossCropSound() {
+        this.worldObj.playSoundEffect(
+            ((double) this.xCoord + 0.5d),
+            ((double) this.yCoord + 0.5d),
+            ((double) this.zCoord + 0.5d),
+            Blocks.planks.stepSound.func_150496_b(),
+            (Blocks.planks.stepSound.getVolume() + 1.0f) / 2.0f,
+            Blocks.planks.stepSound.getPitch() * 0.8f);
     }
 
     // endregion seed planting
@@ -1288,6 +1289,7 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
             }
         } else if (this.isCrossCrop) {
             this.setCrossCrop(false);
+            this.playCrossCropSound();
             if (!player.capabilities.isCreativeMode) {
                 dropItem(new ItemStack(CropsNHBlocks.blockCropSticks, 1));
             }
@@ -1315,6 +1317,7 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
         }
         if (this.isCrossCrop) {
             this.setCrossCrop(false);
+            this.playCrossCropSound();
             if (!player.capabilities.isCreativeMode) {
                 dropItem(new ItemStack(CropsNHBlocks.blockCropSticks, 1));
             }


### PR DESCRIPTION
This PR simply adds noise for removing a cross-crop stick and decouples placement from the noise being added by making it a public function.

https://github.com/user-attachments/assets/988935d6-569b-456b-8eb0-e530d86ef762

