### PR TITLE
The Spice Must Flow: Add Chili Powder back

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
@@ -43,6 +43,7 @@ import com.gtnewhorizon.cropsnh.items.produce.ItemMaterialLeaf;
 import com.gtnewhorizon.cropsnh.loaders.MaterialLeafLoader;
 import com.gtnewhorizon.cropsnh.utility.CropsNHUtils;
 import com.gtnewhorizon.cropsnh.utility.ModUtils;
+import com.gtnewhorizon.cropsnh.utility.OreDictHelper;
 
 import bartworks.common.loaders.BioCultureLoader;
 import bartworks.common.loaders.BioItemList;
@@ -160,6 +161,7 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
         addGaiaWartRecipes();
         addHopsRecipes();
         addCoffeeRecipes();
+        addChiliRecipes();
         addThiosulfineRecipes();
         addIndigoBlossomRecipes();
     }
@@ -262,6 +264,12 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
         GTModHandler.addShapelessCraftingRecipe(
             GTOreDictUnificator.get(OrePrefixes.dust, Materials.Coffee, 1L),
             new Object[] { "craftingToolMortar", "cropCoffee" });
+    }
+
+    private static void addChiliRecipes() {
+        recipe(2, 20 * SECONDS).itemInputs(OreDictHelper.getCopiedOreStack("cropChilipepper", 1))
+            .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Chili, 1L))
+            .addTo(maceratorRecipes);
     }
 
     private static void addHopsRecipes() {


### PR DESCRIPTION
Fixes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25318
Recipe didn't survive the cleanup of https://github.com/GTNewHorizons/GT5-Unofficial/pull/5652 & https://github.com/GTNewHorizons/GT5-Unofficial/pull/6088

Disclaimer: I need a second set of eyes for if this is the right way to write the input. I copied it of CropsPlusPlusRecipes so it should be fine.

OG code in ProcessingCrop.java was:
```java
case "cropChilipepper" -> GTValues.RA.stdBuilder()
    .itemInputs(aStack)                                          // the Chili pepper crop drop
    .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Chili, 1L))  // 1x Chili Powder
    .duration(20 * SECONDS)
    .eut(2)
    .addTo(maceratorRecipes);
```

2.8.4:
<img width="827" height="705" alt="image" src="https://github.com/user-attachments/assets/b4570d30-5790-4ce8-9579-e52dbc53b129" />

2.9.x with this pr: (the other chili type is gone I'm pretty sure)
<img width="621" height="536" alt="image" src="https://github.com/user-attachments/assets/472008b3-1f25-4ae8-b72a-347a1da364aa" />
