### PR TITLE
Bauxia Balance Changes

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
@@ -72,6 +72,8 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
 
     private static final int PURIFIED_RECIPE_CIRCUIT = 1;
     private static final int IMPURE_DUST_RECIPE_CIRCUIT = 2;
+    private static final int SECONDARY_PURIFIED_RECIPE_CIRCUIT = 3;
+    private static final int SECONDARY_IMPURE_DUST_RECIPE_CIRCUIT = 4;
     public static final int DEFAULT_ORE_DUPLICATION_ORE_AMOUNT = 4;
     public static final int DEFAULT_ORE_CONVERSION_LEAF_AMOUNT = 4;
     /** for explicitly telling the game to not add a fluid byproduct. */
@@ -539,7 +541,13 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
         createOreConversionRecipe(MaterialLeafLoader.auroniaLeaf, Voltage.LV, Materials.Gold, TierAcid.t2);
         // emeralds are needed for mv sensors/emitters so slightly higher reqs
         createOreConversionRecipe(MaterialLeafLoader.bobsYerUncleBerry, Voltage.LV, Materials.Emerald, TierAcid.t2);
-        createOreConversionRecipe(MaterialLeafLoader.bauxiaLeaf, Voltage.MV, Materials.Bauxite, TierAcid.t2);
+        createOreConversionRecipe(
+            MaterialLeafLoader.bauxiaLeaf,
+            Voltage.MV,
+            Materials.Aluminium,
+            TierAcid.t2,
+            PURIFIED_RECIPE_CIRCUIT,
+            IMPURE_DUST_RECIPE_CIRCUIT);
 
         for (PlatinaRecipeVariation variation : new PlatinaRecipeVariation[] {
             new PlatinaRecipeVariation(1, 3, WerkstoffLoader.PTResidue.get(OrePrefixes.dustTiny, 1)),
@@ -553,6 +561,17 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
                 .addTo(UniversalChemical);
         }
 
+        // dream mandate: passive bauxite ore generation should be HV at the very least
+        // since crops are significantly easier to produce a lot of stuff from, I'm bumping that gate to EV for crops.
+        // Mostly because the mv recipe still outputs bauxite dust, and is therefore more similar to the bee's output
+        // early on as it's reduced by a ton, and will therefore require a lot more infra to do a moon skip.
+        createOreConversionRecipe(
+            MaterialLeafLoader.bauxiaLeaf,
+            Voltage.EV,
+            Materials.Bauxite,
+            TierAcid.t4,
+            SECONDARY_PURIFIED_RECIPE_CIRCUIT,
+            SECONDARY_IMPURE_DUST_RECIPE_CIRCUIT);
         createOreConversionRecipe(MaterialLeafLoader.scheeliniumLeaf, Voltage.EV, Materials.Scheelite, TierAcid.t5);
         createOreConversionRecipe(MaterialLeafLoader.reactoriaLeaf, Voltage.EV, Materials.Pitchblende, TierAcid.t5);
         createOreConversionRecipe(MaterialLeafLoader.reactoriaStem, Voltage.EV, Materials.Uranium, TierAcid.t6);
@@ -1078,6 +1097,20 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
             -1);
     }
 
+    public static void createOreConversionRecipe(IMaterialLeafVariant variant, Voltage voltage, Materials ore,
+        TierAcid catalyst, int purifiedCircuit, int impureCircuit) {
+        createOreConversionRecipe(
+            variant,
+            DEFAULT_ORE_CONVERSION_LEAF_AMOUNT,
+            voltage,
+            ore,
+            DEFAULT_ORE_CONVERSION_LEAF_AMOUNT,
+            catalyst,
+            -1,
+            purifiedCircuit,
+            impureCircuit);
+    }
+
     public static void createOreConversionRecipe(IMaterialLeafVariant variant, int amount, Voltage voltage,
         Materials ore, TierAcid catalyst, int duration) {
         createOreConversionRecipe(variant, amount, voltage, ore, amount, catalyst, duration);
@@ -1085,6 +1118,20 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
 
     public static void createOreConversionRecipe(IMaterialLeafVariant variant, int leafAmount, Voltage voltage,
         Materials ore, int oreAmount, TierAcid catalyst, int duration) {
+        createOreConversionRecipe(
+            variant,
+            leafAmount,
+            voltage,
+            ore,
+            oreAmount,
+            catalyst,
+            duration,
+            PURIFIED_RECIPE_CIRCUIT,
+            IMPURE_DUST_RECIPE_CIRCUIT);
+    }
+
+    public static void createOreConversionRecipe(IMaterialLeafVariant variant, int leafAmount, Voltage voltage,
+        Materials ore, int oreAmount, TierAcid catalyst, int duration, int purifiedCircuit, int impureCircuit) {
         if (variant == null || voltage == null || ore == null) {
             throw new IllegalArgumentException("variant, voltage and outputFluid cannot be null.");
         }
@@ -1103,7 +1150,7 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
         createOreConversionRecipe(
             voltage,
             duration,
-            new ItemStack[] { leaf, GTUtility.getIntegratedCircuit(PURIFIED_RECIPE_CIRCUIT) },
+            new ItemStack[] { leaf, GTUtility.getIntegratedCircuit(purifiedCircuit) },
             acid,
             purified,
             null,
@@ -1111,7 +1158,7 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
         createOreConversionRecipe(
             voltage,
             duration,
-            new ItemStack[] { leaf, GTUtility.getIntegratedCircuit(IMPURE_DUST_RECIPE_CIRCUIT) },
+            new ItemStack[] { leaf, GTUtility.getIntegratedCircuit(impureCircuit) },
             acid,
             impureDust,
             null,


### PR DESCRIPTION
I asked Dream for his take on Bauxia since it allows a fairly easy moon skip, as Bauxia and crops in general can generate quite a lot of resources/drops early on, and this is the result of that conversation.

The gist of it is that:
- Bauxite _ore_ generation shouldn't be possible before HV, _period_.
- Bauxite _dust_ generation pre-HV is mostly fine as it is, as it requires a lot more investment to get anything bauxite-related when using it.

With that goal in mind, this PR makes some changes to the bauxia leaf recipes to better gate their outputs:
- Bauxite ore production was moved from an MV recipe to an EV recipe
  - Now requires at the very least ownership of enough titanium to make an EV forge hammer and an HV->EV transformer
  - Also changed the acid from HCL to HF, mostly because HCL isn't that hard to make once you get moon salt water or salt root sorted out, and HF requires more effort to get, as the only real passive sources of fluorine are stuff like the cryolite bee and black stone lilies)
  - Now uses circuits 3 and 4 for the pure/impure recipes instead of 1 and 2 to properly seperate them.
- The existing recipe now outputs aluminum ore, which has a much smaller byproduct chance for bauxite.

A goal of mine has always been for crops to be an extension of what the player already has access to, not an avenue for unlocking new resources, so these changes also align with these principles.

As I promised Dream, I'll also be making a similar PR to GT5u for the bauxite comb shortly, bumping it to HV, as the bauxite comb has a much lower drop rate than bauxia and therefore requires a lot more investment.

---

Screenshots
<img width="511" height="1021" alt="image" src="https://github.com/user-attachments/assets/8b0f38a9-fd75-4c86-86a3-847ed564eb34" />
<img width="515" height="955" alt="image" src="https://github.com/user-attachments/assets/2d3df268-62d5-4a8b-ab82-442bedd75fe2" />
