### PR TITLE
fix: adapt to new ItemEjectionHelper API parameters

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    devOnlyNonPublishable("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.601:dev")
+    devOnlyNonPublishable("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.618:dev")
     devOnlyNonPublishable("com.github.GTNewHorizons:GTNHLib:0.11.15:dev") { transitive = false }
     devOnlyNonPublishable("com.github.GTNewHorizons:TinkersConstruct:1.14.91-GTNH:dev") { transitive = false }
     devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.102-GTNH:dev") { transitive = false }

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
@@ -1285,7 +1285,7 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
         tDropProgess.addTo(this.mOutputTracker, tSeedData.getStack().stackSize);
         // check if output void protection is enabled
         if (this.voidingMode.protectItem) {
-            ItemEjectionHelper tHelper = new ItemEjectionHelper(this.getOutputBusses(), true);
+            ItemEjectionHelper tHelper = new ItemEjectionHelper(this.getOutputBusses(), true, true);
             ItemStack[] tDrops = this.mOutputTracker.getDrops(true);
             if (tDrops.length != 0 && tHelper.ejectItems(Arrays.asList(tDrops), 1) <= 0) {
                 // remove the added items


### PR DESCRIPTION
I recently changed the `ItemEjectionHelper`, it now requires an `isRecipeCheck` boolean parameter.
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25429