### PR TITLE
Balance Tweaks for 2.9

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,51 +1,51 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.618:dev")
-    api("com.github.GTNewHorizons:GTNHLib:0.11.15:dev")
-    devOnlyNonPublishable("com.github.GTNewHorizons:TinkersConstruct:1.14.91-GTNH:dev") { transitive = false }
-    devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.102-GTNH:dev") { transitive = false }
+    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.53.14:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.11.19:dev")
+    devOnlyNonPublishable("com.github.GTNewHorizons:TinkersConstruct:1.14.93-GTNH:dev") { transitive = false }
+    devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.105-GTNH:dev") { transitive = false }
     devOnlyNonPublishable("com.github.GTNewHorizons:waila:1.19.30:dev") { transitive = false }
-    devOnlyNonPublishable("com.github.GTNewHorizons:ForestryMC:4.11.26:dev") { transitive = false }
+    devOnlyNonPublishable("com.github.GTNewHorizons:ForestryMC:4.11.28:dev") { transitive = false }
     devOnlyNonPublishable("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
     devOnlyNonPublishable('com.github.GTNewHorizons:Backhand:1.8.10:dev') { transitive = false }
     devOnlyNonPublishable('com.github.GTNewHorizons:FindIt:1.4.3:dev') { transitive = false }
 
 
     // // debugging tools
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:NewHorizonsCoreMod:2.8.286:dev")
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:ServerUtilities:2.3.1:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:NewHorizonsCoreMod:2.8.298:dev")
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:ServerUtilities:2.4.1:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:worldedit-gtnh:v0.0.9:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:WAILAPlugins:0.7.2:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:EnderCore:0.5.14:dev") { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.102-GTNH:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.105-GTNH:dev") { transitive = false }
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:Opis:1.4.8-mapless:dev') { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:GTNHLib:0.11.15:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:GTNHLib:0.11.19:dev") { transitive = false }
     // // QOL/creature comforts
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-981-GTNH:dev") { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.5.90-gtnh:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-992-GTNH:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.5.95-gtnh:dev") { transitive = false }
     // var tasks = project.gradle.startParameter.taskNames
     // if (tasks.contains("runClient17") || tasks.contains("runClient21")) {
-    //     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Angelica:2.1.36:dev") { transitive = false }
+    //     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Angelica:2.1.43:dev") { transitive = false }
     // }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Hodgepodge:2.7.161:dev") { transitive = false }
-    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:CoreTweaks:0.3.4.6-GTNH:dev') { transitive = false }
-    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:StorageDrawers:2.2.25-GTNH:dev') { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Hodgepodge:2.7.166:dev") { transitive = false }
+    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:CoreTweaks:0.3.4.7-GTNH:dev') { transitive = false }
+    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:StorageDrawers:2.2.26-GTNH:dev') { transitive = false }
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:MouseTweaks:2.5.2-GTNH:dev') { transitive = false }
     // // rendering IF structure in NEI
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:StructureLib:1.4.38:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:StructureLib:1.4.40:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:BlockRenderer6343:1.4.14:dev") { transitive = false }
     // // to check what counts as food
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:AppleCore:3.3.11:dev") { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:SpiceOfLife:2.2.9-carrot:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:SpiceOfLife:2.2.10-carrot:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Nutrition:0.1.9:dev") { transitive = false }
     // // bee comparisons
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:BeeBetterAtBees-GTNH:0.4.6-GTNH:dev") { transitive = false }
-    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:Binnie:2.6.32:dev') { transitive = false }
+    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:Binnie:2.6.34:dev') { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:neiaddons:1.18.1:dev") { transitive = false }
     // // for mod specific crops
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Natura:2.8.19:dev") { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:twilightforest:2.7.33:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:twilightforest:2.7.35:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:ThaumicBases:1.9.18:dev") { transitive = false }
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:DummyCore:1.21.0:dev') { transitive = false }
     // runtimeOnlyNonPublishable("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
@@ -56,19 +56,19 @@ dependencies {
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:harvestcraft:1.3.11-GTNH:dev") { transitive = false }
     // // testing recipes
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Tainted-Magic:7.7.8-GTNH:dev") { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:WitcheryExtras:1.4.15:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:WitcheryExtras:1.4.16:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:WitchingGadgets:1.8.48-GTNH:dev") { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:ThaumicTinkerer:2.12.23:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:ThaumicTinkerer:2.12.25:dev") { transitive = false }
     // // required in order to have pam
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Chisel:2.17.26-GTNH:dev") { transitive = false }
     // // mod specific crops and soils
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Galacticraft:3.4.29-GTNH:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Galacticraft:3.4.30-GTNH:dev") { transitive = false }
     // // soil debugging
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Random-Things:2.7.7:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Random-Things:2.7.8:dev") { transitive = false }
     // runtimeOnlyNonPublishable(rfg.deobf("curse.maven:ztones-224369:2223720")) { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:MagicBees:2.10.9-GTNH:dev") { transitive = false }
     // // required in order for ztones to load right due to GT5u
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:BuildCraft:7.1.60:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:BuildCraft:7.1.61:dev") { transitive = false }
     // // skull underblock requirement
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:EnderIO:2.10.31:dev') { transitive = false }
     // // watering can interactions

--- a/src/main/java/com/gtnewhorizon/cropsnh/api/CropsNHBlockUnderTypes.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/api/CropsNHBlockUnderTypes.java
@@ -68,4 +68,5 @@ public final class CropsNHBlockUnderTypes {
     public static final BlockUnderRequirement space = BlockUnderRequirement.get("space");
     public static final BlockUnderRequirement ruby = BlockUnderRequirement.get("ruby");
     public static final BlockUnderRequirement sulfur = BlockUnderRequirement.get("sulfur");
+    public static final BlockUnderRequirement steeleaf = BlockUnderRequirement.get("steeleaf");
 }

--- a/src/main/java/com/gtnewhorizon/cropsnh/crops/material/CropSteeleafranks.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/crops/material/CropSteeleafranks.java
@@ -4,6 +4,7 @@ import java.awt.Color;
 
 import net.minecraftforge.common.BiomeDictionary;
 
+import com.gtnewhorizon.cropsnh.api.CropsNHBlockUnderTypes;
 import com.gtnewhorizon.cropsnh.api.CropsNHSoilTypes;
 import com.gtnewhorizon.cropsnh.api.ISoilList;
 import com.gtnewhorizon.cropsnh.crops.abstracts.NHCropCard;
@@ -25,6 +26,8 @@ public class CropSteeleafranks extends NHCropCard {
 
         this.addDuplicationCatalyst("dustSteeleaf", 1);
         this.addDuplicationCatalyst("ingotSteeleaf", 1);
+
+        this.addBlockUnderRequirement(CropsNHBlockUnderTypes.steeleaf);
 
         this.addLikedBiomes(BiomeDictionary.Type.SPOOKY, BiomeDictionary.Type.DEAD);
     }

--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/BlockUnderRequirementLoader.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/BlockUnderRequirementLoader.java
@@ -91,6 +91,7 @@ public class BlockUnderRequirementLoader {
         CropsNHBlockUnderTypes.ruby.addBlockAndOreDict().addMaterial(Materials.Ruby);
         // non-gt ores
         CropsNHBlockUnderTypes.knightmetal.addBlockAndOreDict().addMaterial(Materials.Knightmetal);
+        CropsNHBlockUnderTypes.steeleaf.addBlockAndOreDict().addMaterial(Materials.Steeleaf);
         CropsNHBlockUnderTypes.cobalt.addBlockAndOreDict().addMaterial(Materials.Cobalt);
         CropsNHBlockUnderTypes.ardite.addBlockAndOreDict().addMaterial(Materials.Ardite);
         // magic ores

--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/BlockUnderRequirementLoader.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/BlockUnderRequirementLoader.java
@@ -325,6 +325,12 @@ public class BlockUnderRequirementLoader {
                 new BlockWithMeta(ModUtils.ThaumicBases.getBlock("oldCobbleMossy"))
             );
         }
+        if (ModUtils.TwilightForest.isModLoaded()) {
+            // the TF Steeleaf block doesn't have the blockSteeleaf ore dict for some reason
+            CropsNHBlockUnderTypes.steeleaf.addBlock(
+                new BlockWithMeta(ModUtils.TwilightForest.getBlock("tile.SteeleafBlock"))
+            );
+        }
         // spotless:on
     }
 }

--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
@@ -952,7 +952,7 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
 
         // lock borax production to the tier the chembath multi unlocks (grisium right now, which is ev)
         // only reduce recipe time by 1 OC to imply the much thorough washing required to get borax.
-        evRecipe(2, 5).itemInputs(MaterialLeafLoader.saltyRoot.get(1))
+        evRecipe(2, 50).itemInputs(MaterialLeafLoader.saltyRoot.get(1))
             .circuit(2)
             .fluidInputs(new FluidStack(FluidRegistry.WATER, 100))
             .itemOutputs(

--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
@@ -36,8 +36,10 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
+import com.gtnewhorizon.cropsnh.api.CropsNHCrops;
 import com.gtnewhorizon.cropsnh.api.CropsNHItemList;
 import com.gtnewhorizon.cropsnh.api.IMaterialLeafVariant;
+import com.gtnewhorizon.cropsnh.farming.SeedStats;
 import com.gtnewhorizon.cropsnh.handler.CropsNHFurnaceFuelHandler;
 import com.gtnewhorizon.cropsnh.items.produce.ItemMaterialLeaf;
 import com.gtnewhorizon.cropsnh.loaders.MaterialLeafLoader;
@@ -253,10 +255,6 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
             .circuit(IMPURE_DUST_RECIPE_CIRCUIT)
             .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dustImpure, mainMaterial, 1))
             .addTo(LanthanidesRecipeMaps.digesterRecipes);
-
-    }
-
-    private static void addThiosulfineDigesterRecipes(GTRecipeBuilder builder, Materials material, IRecipeMap map) {
 
     }
 
@@ -652,15 +650,18 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
     private static void addMagicEssenceRecipes() {
         if (!ModUtils.Thaumcraft.isModLoaded()) return;
         Item thaumResourceItem = GameRegistry.findItem(ModUtils.Thaumcraft.ID, "ItemResource");
+
         // salis mundus extraction
         ulvRecipe(3, 20).itemInputs(MaterialLeafLoader.magicEssence.get(1))
             .itemOutputs(new ItemStack(thaumResourceItem, 16, 14))
             .addTo(RecipeMaps.extractorRecipes);
+
         // iron to thaumium conversion
         mvRecipe(12, 0).itemInputs(new Object[] { "dustIron", 4 }, CropsNHItemList.magicEssence.get(1))
             .fluidInputs(TierAcid.t1.get(1000))
             .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Thaumium, 4))
             .addTo(GTRecipeConstants.UniversalChemical);
+
         // thaumium to void conversion
         hvRecipe(12, 0)
             .itemInputs(
@@ -670,6 +671,7 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
             .fluidInputs(TierAcid.t2.get(4000))
             .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Void, 4))
             .addTo(multiblockChemicalReactorRecipes);
+
         if (ModUtils.TaintedMagic.isModLoaded()) {
             // void to shadow metal conversion
             ivRecipe(12, 0).itemInputs(new Object[] { "dustVoid", 4 }, CropsNHItemList.magicEssence.get(4))
@@ -690,6 +692,50 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
                     .addTo(multiblockChemicalReactorRecipes);
             }
         }
+
+        // knightmetal -> Steeleaf
+        // Steeleafranks is a _very_ lazy steel source that used to be accessible to players without much of any
+        // investment, it's slow growth speed was intended to maintain it's viability in the early tiers, but it's clear
+        // that players will simply get around this by simply using larger fields, as the steps to produce steel from
+        // steeleaf are simply that much faster than the intended BBF route.
+        //
+        // Since steeleaf is usually an exploration reward, the conversion recipe makes sense and probably should be
+        // left as is for regular players to enjoy, so the crop itself has been adjusted in order to not penalize
+        // regular players.
+        //
+        // My current solution is to lock the access to steeleaf to the ownership of steeleaf blocks, while this isn't
+        // exactly the most effective solution (a dim lock requirement would be much more effective since the portal
+        // device is locked to LV circuits), this will at least require a lot more setup in order to scale up the farms
+        // to become viable.
+        //
+        // Adding dim requirements would require pushing forward some new features during a feature freeze, so that's
+        // on hold for now, unless it's approved at which point I'll pr the dev branch i've been working on that adds
+        // these locks and the minimum breeding req systems.
+        //
+        // The below requirement is a stop gap measure, as steeleafranks is the only alternative route GoG can use to
+        // get steeleaf usually aside from guessing where the snow queen castle is and somehow setting up a mob farm
+        // within the bounding box. The below recipe makes up for this by essentially requirering deep bee and crop
+        // progression and relies on the questbook's reward of a single steeleaf block for obtaining a steeleafranks
+        // seed, allowing players to then propagate it.
+        // TODO: REMOVE ONCE MULTI THAT MAKES TF RESOURCES IS ADDED TO GTNH (CURRENTLY AIMED AT 2.10)
+        if (ModUtils.TwilightForest.isModLoaded() && ModUtils.NewHorizonsCoreMod.isModLoaded()) {
+            hvRecipe(60, 0).fluidInputs(Materials.FierySteel.getMolten(INGOTS * 64))
+                .itemInputs(
+                    CropsNHItemList.magicEssence.get(64),
+                    // the "natural components"
+                    new ItemStack(Blocks.leaves, 64, 0),
+                    ModUtils.TwilightForest.getStack("item.torchberries", 64, 0),
+                    ModUtils.TwilightForest.getStack("item.liveRoot", 64, 0),
+                    // infuse some more magical steel™
+                    ModUtils.TwilightForest.getStack("item.shardCluster", 64, 0),
+                    // requires the entire TF bee progression
+                    ModUtils.NewHorizonsCoreMod.getStack("SnowQueenBlood", 16, 0))
+                // give out the seed as the quest book currently gives out a steeleaf block for obtaining a seed.
+                .itemOutputs(CropsNHCrops.Steeleafranks.getSeedItem(SeedStats.DEFAULT_ANALYZED))
+                .addTo(multiblockChemicalReactorRecipes);
+        }
+
+        // Platinum + Meteoric Iron -> Mytryl
         if (ModUtils.GalacticraftCore.isModLoaded()) {
             ivRecipe(90, 0).itemInputs(CropsNHItemList.spaceFlower.get(16), CropsNHItemList.magicEssence.get(4))
                 .fluidInputs(
@@ -699,6 +745,7 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
                 .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Mytryl, 1))
                 .addTo(multiblockChemicalReactorRecipes);
         }
+
         // Magic essence from salis
         hvRecipe(7, 50).itemInputs(new ItemStack(thaumResourceItem, 64, 14))
             .fluidInputs(Materials.Void.getMolten(16 * INGOTS))

--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
@@ -28,6 +28,9 @@ import static gregtech.common.items.ItemComb.Voltage;
 import static gtPlusPlus.api.recipe.GTPPRecipeMaps.quantumForceTransformerRecipes;
 import static net.minecraftforge.fluids.FluidRegistry.getFluidStack;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
@@ -69,6 +72,8 @@ import gregtech.loaders.misc.GTBees;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 import gtPlusPlus.xmod.thermalfoundation.fluid.TFFluids;
 import gtnhlanth.api.recipe.LanthanidesRecipeMaps;
+import it.unimi.dsi.fastutil.ints.IntObjectImmutablePair;
+import it.unimi.dsi.fastutil.ints.IntObjectPair;
 
 public abstract class CropRecipes extends BaseGTRecipeLoader {
 
@@ -393,10 +398,26 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
         createOreDuplicationRecipe(MaterialLeafLoader.pyrolusiumLeaf, Materials.Grossular);
         createOreDuplicationRecipe(MaterialLeafLoader.pyrolusiumLeaf, Materials.Spessartine);
         createOreDuplicationRecipe(MaterialLeafLoader.pyrolusiumLeaf, Materials.Pyrolusite);
-        createOreDuplicationRecipe(
-            MaterialLeafLoader.pyrolusiumLeaf,
-            Materials.Tantalite,
-            Materials.Tantalum.getMolten(1 * INGOTS));
+        createOreDuplicationRecipe(MaterialLeafLoader.pyrolusiumLeaf, Materials.Tantalite);
+
+        final List<IntObjectPair<OrePrefixes>> tantaliteEBFVariations = new ArrayList<>(2);
+        tantaliteEBFVariations.add(IntObjectImmutablePair.of(PURIFIED_RECIPE_CIRCUIT, OrePrefixes.crushedPurified));
+        tantaliteEBFVariations.add(IntObjectImmutablePair.of(IMPURE_DUST_RECIPE_CIRCUIT, OrePrefixes.dustImpure));
+        for (IntObjectPair<OrePrefixes> variation : tantaliteEBFVariations) {
+            recipe(Voltage.HV.getChemicalEnergy(), Voltage.HV.getComplexTime())
+                .itemInputs(
+                    CropsNHItemList.pyrolusiumLeaf.get(4),
+                    GTOreDictUnificator
+                        .get(OrePrefixes.crushed, Materials.Tantalite, DEFAULT_ORE_DUPLICATION_ORE_AMOUNT))
+                .circuit(variation.leftInt())
+                // meant to mirror however much the usual tantalite persulfate recipe uses.
+                .fluidInputs(Materials.SodiumPersulfate.getFluid(100))
+                .itemOutputs(
+                    GTOreDictUnificator.get(variation.right(), Materials.Tantalite, DEFAULT_ORE_DUPLICATION_ORE_AMOUNT),
+                    GTOreDictUnificator.get(OrePrefixes.ingotHot, Materials.Tantalum, 1))
+                .metadata(COIL_HEAT, 800)
+                .addTo(RecipeMaps.blastFurnaceRecipes);
+        }
 
         createOreDuplicationRecipe(MaterialLeafLoader.titaniaLeaf, Materials.Titanium);
         createOreDuplicationRecipe(MaterialLeafLoader.titaniaLeaf, Materials.Ilmenite);

--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
@@ -874,6 +874,18 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
 
     private static void addSaltyRootRecipes() {
         lvRecipe(5, 0).itemInputs(MaterialLeafLoader.saltyRoot.get(1))
+            .circuit(1)
+            .fluidInputs(new FluidStack(FluidRegistry.WATER, 100))
+            .itemOutputs(
+                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.dust, Materials.Salt, 1),
+                    GTOreDictUnificator.get(OrePrefixes.dust, Materials.RockSalt, 1),
+                    GTOreDictUnificator.get(OrePrefixes.dust, Materials.Saltpeter, 1) },
+                new int[] { 95_00, 80_00, 50_00 })
+            .addTo(chemicalBathRecipes);
+
+        // lock borax production to the tier the chembath multi unlocks (grisium right now, which is ev)
+        evRecipe(5, 0).itemInputs(MaterialLeafLoader.saltyRoot.get(1))
+            .circuit(2)
             .fluidInputs(new FluidStack(FluidRegistry.WATER, 100))
             .itemOutputs(
                 new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.dust, Materials.Salt, 1),

--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
@@ -407,8 +407,7 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
             recipe(Voltage.HV.getChemicalEnergy(), Voltage.HV.getComplexTime())
                 .itemInputs(
                     CropsNHItemList.pyrolusiumLeaf.get(4),
-                    GTOreDictUnificator
-                        .get(OrePrefixes.crushed, Materials.Tantalite, DEFAULT_ORE_DUPLICATION_ORE_AMOUNT))
+                    GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Tantalite, 1))
                 .circuit(variation.leftInt())
                 // meant to mirror however much the usual tantalite persulfate recipe uses.
                 .fluidInputs(Materials.SodiumPersulfate.getFluid(100))

--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
@@ -951,7 +951,8 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
             .addTo(chemicalBathRecipes);
 
         // lock borax production to the tier the chembath multi unlocks (grisium right now, which is ev)
-        evRecipe(5, 0).itemInputs(MaterialLeafLoader.saltyRoot.get(1))
+        // only reduce recipe time by 1 OC to imply the much thorough washing required to get borax.
+        evRecipe(2, 5).itemInputs(MaterialLeafLoader.saltyRoot.get(1))
             .circuit(2)
             .fluidInputs(new FluidStack(FluidRegistry.WATER, 100))
             .itemOutputs(

--- a/src/main/resources/assets/cropsnh/lang/en_US.lang
+++ b/src/main/resources/assets/cropsnh/lang/en_US.lang
@@ -795,6 +795,7 @@ cropsnh_growthReq.blockUnder.sapphire=Needs a block of sapphire under it to grow
 cropsnh_growthReq.blockUnder.ruby=Needs a block of ruby under it to grow
 # Non-GT Ore Growth Requirements
 cropsnh_growthReq.blockUnder.knightmetal=Needs a block of knightmetal under it to grow
+cropsnh_growthReq.blockUnder.steeleaf=Needs a block of steeleaf under it to grow
 cropsnh_growthReq.blockUnder.cobalt=Needs a block of cobalt under it to grow
 cropsnh_growthReq.blockUnder.ardite=Needs a block of ardite under it to grow
 # Magic Ore Growth Requirements


### PR DESCRIPTION
This PR is currently in the works and aims to rebalance some existing crops that are clear outliers in the current sandbox:

- [x] Bauxia
  - Issue: Grants plenty of access to bauxite (and therefore titanium) pre-moon, and therefore makes the moon skip far too viable.
  - Solution: Uptier to EV
  - Reasoning:
    - Unlike the bees, scaling crops early on is a lot easier. You don't have to hunt down queens, and you can all scale it from your base.
    - The crops also output significantly faster than the bee at the early tiers. So much so that an MV crop manager or IF will easily overwhelm a dedicated forge hammer (it outputs roughly enough for ~3 forge hammers to run nonstop with minimal downtime)
    - With a setup running at roughly 1.5a hv, you can process enough leaves to produce roughly ~10 to 15 titanium a minute, which makes the trip to the moon feel kinda pointless, and that system is with the farm running with roughly 10% of the time.
      - If using bauxite slurry, the numbers are even higher.
    - Skips should always be much more difficult than the thing they skip, so the best solution is to bar access to direct bauxite production behind either the moon or the ownership of a significant amount of titanium,
    - Uptiering to EV is by far the best option; Bauxite can easily be obtained from 
  - This issue was already addressed in another PR (#172 ), I'm simply leaving this to log the actual thought behind the unequal tier difference between the new bee and crop recipes.
    - Future solution: Add a dedicated aluminum crop, and remove the aluminum sub-soil option from bauxia

- [x] Salty Root:
  - Issue: the borax output was only intended to be obtainable once you got your hands on the multi-chem bath, as I was under the impression that all chem baths only had 3 output slots. (HV+ chem baths actually have six output slots)
  - Solution:
    - [x] Remove the borax from the existing recipe and add a circuit to distinguish it from the recipe below. The recipe time will remain higher than the original recipe, to imply the more thorough washing required for borax output. My intent is for the bee to be the better early-game producer of borax, so it should work out™.
    - [x] Uptier the existing recipe to EV (the tier at which you can make a chem bath multi) and use a circuit to distinguish it from the old recipe.

- [x] Steeleafranks:
  - Issue: Steeleafanks enables a much higher steel production than the BBF in the early tiers without too much effort, as it centrifuges into steel dust.
  - Solution:
    - [X] Introduce a steel leaf underblock for growth and breeding
    - (optional, pending approval) Introduce a dimension lock to only allow it to be bred in the Twilight Forest.
      - This would be more effective at gating Steeleafanks to Post BBF as the portal device requires LV circuits, and therefore can't be circumvented by another pre-LV circuit Steeleaf source that might be added elsewhere down the line.
      - This requirement will be bypassable using a ZPM or higher crop breeder.
      - The dim locks are something I was planning on adding in 2.10, but if the team will allow me, I would like to forward it into 2.9 if possible, and add these requirements to a few existing crops. (This will be PRd separately and only added to this PR if merged pre 2.9)
    - [x] As GoG is usually dependent on Steeleafranks for steeleaf production for the drone center and Dyson Drones, a magic essence (magical night shade) recipe will be added to allow players to get their hands on a Steeleafranks seed. The quest book rewards players with a steeleaf block for obtaining a Steeleafranks seed, so players should still be able to use it to create more by growing the provided seed. and eventually stat it up once they have enough to make new blocks. 
  - Reasoning:
    - The centrifuge recipe is fine by itself, as outside of crops, as all other sources are either locked to a higher tier (EEC + TF progress to the Ice Queen) or exploration rewards.
    - For a much more detailed reasoning, check the files changed for the skip recipe; it's got all the details.

- [x] Pyrolusium:
  - Issues:
    - Adding the molten tantalum to the tantalite recipe ended up being a bit too strong for the early tiers, and it severely reduces the need to create a vacuum freezer or to rely on the chembath cooling method early on.
    - It also provides access to tantalum MV and significantly reduces the cost of using tantalum for SMD components in HV, without requiring much effort.
  - Solution
    - [x] Remove the liquid tantalum from the existing quadrupling recipe.
    - [x] Add an HV/cupronickel coil recipe to the EBF to also do the quadrupling, and make it output a hot tantalum ingot. Also, make it use sodium persulfate in the same amount as the usual recipe, so it ties in to the existing tantalum yield increase.
  - Reasoning:
    - Tantalum is usually very difficult to get in usable quantities before obtaining ilmenite. It's often referred to as a noob trap because of that fact. Adding something to make tantalum more accessible pre-ilmenite is something I'm down for, but it shouldn't come at the cost of de-incentivizing the player from building/using key base infrastructure components, such as the VF.

# Screenshots
Bauxite not included as that was merged in a seperate pr and isn't actually affected by this pr.

## Salty Root
New regular recipe and borax-producing recipe
<img width="627" height="1003" alt="image" src="https://github.com/user-attachments/assets/1c2bfdcd-7dc7-48ee-aaaf-669d1a897be5" />

## Steeleafranks
stop-gap steeleafranks steeleaf skip recipe
<img width="550" height="578" alt="image" src="https://github.com/user-attachments/assets/f4dea478-4a42-40df-b186-af39c18aa378" />

## Pyrolusium
Quadrupling distilled water
<img width="956" height="923" alt="image" src="https://github.com/user-attachments/assets/43b0b42d-06ae-442c-9498-bd6fd95405e9" />
Quadrupling, regular water
<img width="533" height="1008" alt="image" src="https://github.com/user-attachments/assets/b166b8c3-063b-4f37-a93c-6cc3c7ddf699" />
EBF recipes
<img width="568" height="1062" alt="image" src="https://github.com/user-attachments/assets/86091717-9bbd-4c26-bdcd-465ee77ba4d7" />

