### PR TITLE
Waiter... Waiter! More slots, please!

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/singleblock/MTECropManager.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/singleblock/MTECropManager.java
@@ -50,19 +50,27 @@ public class MTECropManager extends MTETieredMachineBlock {
 
     public static final int WEEDEX_SLOT_COUNT = 2;
     public static final int FERTILIZER_SLOT_COUNT = 4;
-    public static final int OUTPUT_SLOT_COUNT = 15;
     public static final int BATTERY_SLOT_COUNT = 1;
-    public static final int TOTAL_SLOT_COUNT = WEEDEX_SLOT_COUNT + FERTILIZER_SLOT_COUNT
-        + OUTPUT_SLOT_COUNT
-        + BATTERY_SLOT_COUNT;
+
+    // The output (internal harvest storage) region scales with tier; every other region is fixed.
+    public static int getOutputSlotCount(int aTier) {
+        return 5 * (aTier + 2);
+    }
+
+    public static int getTotalSlotCount(int aTier) {
+        return WEEDEX_SLOT_COUNT + FERTILIZER_SLOT_COUNT + getOutputSlotCount(aTier) + BATTERY_SLOT_COUNT;
+    }
 
     public static final int SLOT_WEEDEX_START = 0;
     public static final int SLOT_WEEDEX_END = SLOT_WEEDEX_START - 1 + WEEDEX_SLOT_COUNT;
     public static final int SLOT_FERT_START = SLOT_WEEDEX_END + 1;
     public static final int SLOT_FERT_END = SLOT_FERT_START - 1 + FERTILIZER_SLOT_COUNT;
     public static final int SLOT_OUTPUT_START = SLOT_FERT_END + 1;
-    public static final int SLOT_OUTPUT_END = SLOT_OUTPUT_START - 1 + OUTPUT_SLOT_COUNT;
-    public static final int SLOT_BATTERY = SLOT_OUTPUT_END + 1;
+
+    // Tier-dependent slot layout; assigned in the constructor once mTier is known.
+    public final int mOutputSlotCount;
+    public final int mSlotOutputEnd;
+    public final int mSlotBattery;
 
     // run ever 2.5s, refresh cache every other run when empty, else wait 60s to refresh cache
     private final static int GLOBAL_UPDATE_RATE = 2 * 20 + 10;
@@ -93,8 +101,11 @@ public class MTECropManager extends MTETieredMachineBlock {
             String.format("basicmachine.cropManager.tier.%02d", aTier),
             StatCollector.translateToLocalFormatted(Reference.MOD_ID + "_tooltip.cropManager.name." + aTier),
             aTier,
-            TOTAL_SLOT_COUNT,
+            getTotalSlotCount(aTier),
             StatCollector.translateToLocal("cropsnh_tooltip.cropManager.description"));
+        this.mOutputSlotCount = getOutputSlotCount(this.mTier);
+        this.mSlotOutputEnd = SLOT_OUTPUT_START - 1 + this.mOutputSlotCount;
+        this.mSlotBattery = this.mSlotOutputEnd + 1;
         this.mWater = 0;
         this.mWaterCap = this.mTier * 32000;
         this.mWeedEX = 0;
@@ -108,7 +119,10 @@ public class MTECropManager extends MTETieredMachineBlock {
 
     public MTECropManager(final String aName, final int aTier, final String[] aDescription,
         final ITexture[][][] aTextures) {
-        super(aName, aTier, TOTAL_SLOT_COUNT, aDescription, aTextures);
+        super(aName, aTier, getTotalSlotCount(aTier), aDescription, aTextures);
+        this.mOutputSlotCount = getOutputSlotCount(this.mTier);
+        this.mSlotOutputEnd = SLOT_OUTPUT_START - 1 + this.mOutputSlotCount;
+        this.mSlotBattery = this.mSlotOutputEnd + 1;
         this.mWater = 0;
         this.mWaterCap = this.mTier * 32000;
         this.mWeedEX = 0;
@@ -129,7 +143,7 @@ public class MTECropManager extends MTETieredMachineBlock {
 
     @Override
     public int getSizeInventory() {
-        return TOTAL_SLOT_COUNT;
+        return getTotalSlotCount(this.mTier);
     }
 
     @Override
@@ -189,12 +203,12 @@ public class MTECropManager extends MTETieredMachineBlock {
 
     @Override
     public int rechargerSlotStartIndex() {
-        return SLOT_BATTERY;
+        return mSlotBattery;
     }
 
     @Override
     public int dechargerSlotStartIndex() {
-        return SLOT_BATTERY;
+        return mSlotBattery;
     }
 
     @Override
@@ -311,7 +325,7 @@ public class MTECropManager extends MTETieredMachineBlock {
     // region harvesting
 
     public boolean doesInventoryHaveSpace() {
-        for (int i = SLOT_OUTPUT_START; i <= SLOT_OUTPUT_END; i++) {
+        for (int i = SLOT_OUTPUT_START; i <= mSlotOutputEnd; i++) {
             if (this.mInventory[i] == null || this.mInventory[i].stackSize < 64) {
                 return true;
             }
@@ -373,7 +387,7 @@ public class MTECropManager extends MTETieredMachineBlock {
     }
 
     private int tryInsertOutputStack(ItemStack aDropItem, int remaining) {
-        for (int slot = SLOT_OUTPUT_START; slot <= SLOT_OUTPUT_END && remaining > 0; slot++) {
+        for (int slot = SLOT_OUTPUT_START; slot <= mSlotOutputEnd && remaining > 0; slot++) {
             // compute the max we can transfer at once.
             ItemStack invStack = mInventory[slot];
             int maxStackSize = Math.min(aDropItem.getMaxStackSize(), this.getInventoryStackLimit());
@@ -654,7 +668,7 @@ public class MTECropManager extends MTETieredMachineBlock {
     @Override
     public boolean allowPullStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
         ItemStack aStack) {
-        return aStack != null && aIndex >= SLOT_OUTPUT_START && aIndex <= SLOT_OUTPUT_END;
+        return aStack != null && aIndex >= SLOT_OUTPUT_START && aIndex <= mSlotOutputEnd;
     }
 
     @Override
@@ -663,14 +677,14 @@ public class MTECropManager extends MTETieredMachineBlock {
         return allowPutStack(aIndex, aStack);
     }
 
-    public static boolean allowPutStack(int aIndex, ItemStack aStack) {
+    public boolean allowPutStack(int aIndex, ItemStack aStack) {
         if (aStack != null) {
             if (isFertilizerStack(aStack)) {
                 return aIndex >= SLOT_FERT_START && aIndex <= SLOT_FERT_END;
             } else if (isWeedEXCan(aStack)) {
                 return aIndex >= SLOT_WEEDEX_START && aIndex <= SLOT_WEEDEX_END;
             } else if (isBattery(aStack)) {
-                return aIndex == SLOT_BATTERY;
+                return aIndex == mSlotBattery;
             }
         }
         return false;

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/singleblock/MTECropManagerGui.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/singleblock/MTECropManagerGui.java
@@ -17,6 +17,8 @@ import com.cleanroommc.modularui.value.sync.DoubleSyncValue;
 import com.cleanroommc.modularui.value.sync.IntSyncValue;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
 import com.cleanroommc.modularui.widget.ParentWidget;
+import com.cleanroommc.modularui.widget.scroll.VerticalScrollData;
+import com.cleanroommc.modularui.widgets.ListWidget;
 import com.cleanroommc.modularui.widgets.ProgressWidget;
 import com.cleanroommc.modularui.widgets.ToggleButton;
 import com.cleanroommc.modularui.widgets.layout.Flow;
@@ -39,9 +41,20 @@ public class MTECropManagerGui extends MTETieredMachineBlockBaseGui<MTECropManag
     private static final int LEFT_GRID_ROWS = (int) Math.ceil((float) LEFT_GRID_SLOT_COUNT / LEFT_GRID_COLS);
 
     private static final int RIGHT_GRID_SLOT_START = MTECropManager.SLOT_OUTPUT_START;
-    private static final int RIGHT_GRID_SLOT_COUNT = MTECropManager.OUTPUT_SLOT_COUNT;
     private static final int RIGHT_GRID_COLS = 5;
-    private static final int RIGHT_GRID_ROWS = (int) Math.ceil((float) RIGHT_GRID_SLOT_COUNT / RIGHT_GRID_COLS);
+    // How many output rows the original (LV) layout fit; the panel grows from this baseline.
+    private static final int RIGHT_GRID_BASELINE_ROWS = 3;
+    // Cap on rows shown at once; beyond this the output grid scrolls instead of growing the panel.
+    private static final int RIGHT_GRID_MAX_VISIBLE_ROWS = 6;
+    // Scrollbar width, reserved as a gutter to the right of the slots so it stays clickable.
+    private static final int SCROLLBAR_THICKNESS = 6;
+
+    // The output region scales with tier, so these depend on the machine instance.
+    private final int rightGridSlotCount;
+    private final int rightGridRows;
+    private final int rightGridVisibleRows;
+    // Non-zero only when the output grid actually scrolls, so non-scrolling tiers keep the original width.
+    private final int scrollbarGutter;
 
     private static final String SYNC_INV_HANDLER_NAME = "item_inv";
     private static final String SYNC_WATER_HANDLER_NAME = "water";
@@ -50,6 +63,23 @@ public class MTECropManagerGui extends MTETieredMachineBlockBaseGui<MTECropManag
 
     public MTECropManagerGui(MTECropManager machine) {
         super(machine);
+        this.rightGridSlotCount = machine.mOutputSlotCount;
+        this.rightGridRows = (int) Math.ceil((float) this.rightGridSlotCount / RIGHT_GRID_COLS);
+        this.rightGridVisibleRows = Math.min(this.rightGridRows, RIGHT_GRID_MAX_VISIBLE_ROWS);
+        this.scrollbarGutter = this.rightGridRows > this.rightGridVisibleRows ? SCROLLBAR_THICKNESS : 0;
+    }
+
+    @Override
+    protected int getBasePanelHeight() {
+        // Grow the panel to fit the visible output rows, up to the scroll cap.
+        int extraRows = Math.max(0, rightGridVisibleRows - RIGHT_GRID_BASELINE_ROWS);
+        return super.getBasePanelHeight() + extraRows * MTETieredMachineBlockBaseGui.SLOT_SIZE;
+    }
+
+    @Override
+    protected int getBasePanelWidth() {
+        // Widen the panel to make room for the scrollbar gutter when the output grid scrolls.
+        return super.getBasePanelWidth() + scrollbarGutter;
     }
 
     private ItemSlot createSlot(int aIndex) {
@@ -67,12 +97,12 @@ public class MTECropManagerGui extends MTETieredMachineBlockBaseGui<MTECropManag
             modularSlot.slotGroup(SYNC_INV_HANDLER_NAME);
         }
         // add overlay for fertilizer slots
-        else if (aIndex == MTECropManager.SLOT_BATTERY) {
+        else if (aIndex == machine.mSlotBattery) {
             itemSlot.backgroundOverlay(GTGuiTextures.OVERLAY_SLOT_CHARGER);
             modularSlot.slotGroup(SYNC_INV_HANDLER_NAME);
         }
         // prevent inserting into output slots
-        else if (aIndex >= MTECropManager.SLOT_OUTPUT_START && aIndex <= MTECropManager.SLOT_OUTPUT_END) {
+        else if (aIndex >= MTECropManager.SLOT_OUTPUT_START && aIndex <= machine.mSlotOutputEnd) {
             modularSlot.accessibility(false, true);
         }
 
@@ -91,7 +121,7 @@ public class MTECropManagerGui extends MTETieredMachineBlockBaseGui<MTECropManag
         String percSyncHandlerName = syncHandlerNameBase + "Perc";
         syncManager.syncValue(percSyncHandlerName, perc);
 
-        final int height = Math.max(LEFT_GRID_ROWS, RIGHT_GRID_ROWS) * MTETieredMachineBlockBaseGui.SLOT_SIZE;
+        final int height = Math.max(LEFT_GRID_ROWS, rightGridVisibleRows) * MTETieredMachineBlockBaseGui.SLOT_SIZE;
         // create widget
         return new ProgressWidget().syncHandler(percSyncHandlerName)
             .tooltipDynamic(
@@ -155,11 +185,20 @@ public class MTECropManagerGui extends MTETieredMachineBlockBaseGui<MTECropManag
                     CropsNHUITextures.PROGRESSBAR_CROP_MANAGER_LIQUID_FERTILIZER,
                     Reference.MOD_ID + "_tooltip.cropManager.liquidFertilizerStorage"));
 
-        Grid rightGrid = new Grid().coverChildren()
-            .gridOfSizeWidth(
-                RIGHT_GRID_SLOT_COUNT,
-                RIGHT_GRID_COLS,
-                ($x, $y, i) -> createSlot(i + RIGHT_GRID_SLOT_START));
+        // The output grid scales with tier; wrap it in a fixed-height scroll box so it never overflows the panel.
+        // The slots stay left-aligned and the scrollbar lives in the reserved gutter on the right.
+        ListWidget<IWidget, ?> rightGrid = new ListWidget<>()
+            .size(
+                RIGHT_GRID_COLS * MTETieredMachineBlockBaseGui.SLOT_SIZE + scrollbarGutter,
+                rightGridVisibleRows * MTETieredMachineBlockBaseGui.SLOT_SIZE)
+            .crossAxisAlignment(Alignment.CrossAxis.START)
+            .scrollDirection(new VerticalScrollData(false, SCROLLBAR_THICKNESS));
+        rightGrid.child(
+            new Grid().coverChildren()
+                .gridOfSizeWidth(
+                    rightGridSlotCount,
+                    RIGHT_GRID_COLS,
+                    ($x, $y, i) -> createSlot(i + RIGHT_GRID_SLOT_START)));
 
         Flow topLayer = Flow.row()
             .horizontalCenter()
@@ -238,7 +277,7 @@ public class MTECropManagerGui extends MTETieredMachineBlockBaseGui<MTECropManag
                     .marginLeft(MTETieredMachineBlockBaseGui.SLOT_SIZE)
                     .mainAxisAlignment(Alignment.MainAxis.CENTER)
                     .childIf(this.supportsMuffler(), this::createMufflerButton))
-            .child(createSlot(MTECropManager.SLOT_BATTERY))
+            .child(createSlot(machine.mSlotBattery))
             .child(
                 Flow.row()
                     .width(MTETieredMachineBlockBaseGui.SLOT_SIZE)


### PR DESCRIPTION
Adds more slots to Crop Manager based on tiers.

Basically what the title and branch name says. Crop manager already gets more fluids per tier, so may as well get more slots to go with it. Also solves the problem that a lot of the even moderately higher tier crop managers void half the outputs of their fields since it tends to harvest a decent amount of crops per cycle.