### PR TITLE
Fix gog steeleaf skip

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
@@ -746,8 +746,6 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
                     new ItemStack(Blocks.leaves, 64, 0),
                     ModUtils.TwilightForest.getStack("item.torchberries", 64, 0),
                     ModUtils.TwilightForest.getStack("item.liveRoot", 64, 0),
-                    // infuse some more magical steel™
-                    ModUtils.TwilightForest.getStack("item.shardCluster", 64, 0),
                     // requires the entire TF bee progression
                     ModUtils.NewHorizonsCoreMod.getStack("SnowQueenBlood", 16, 0))
                 // give out the seed as the quest book currently gives out a steeleaf block for obtaining a seed.


### PR DESCRIPTION
I forgot that the knightmetal skip also required steeleaf, so better take the knight metal out for now, the snow queen blood drops will more than cover for the prog requirements anyway.
<img width="515" height="349" alt="image" src="https://github.com/user-attachments/assets/6c5c24a0-f669-479d-9793-0dbc0de4d8b8" />
