### PR TITLE
Allow mature crops to still check their growth reqs.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,9 +2,9 @@
 
 dependencies {
     api("com.github.GTNewHorizons:GT5-Unofficial:5.09.54.09:dev")
-    api("com.github.GTNewHorizons:GTNHLib:0.11.20:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.11.21:dev")
     devOnlyNonPublishable("com.github.GTNewHorizons:TinkersConstruct:1.14.93-GTNH:dev") { transitive = false }
-    devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.109-GTNH:dev") { transitive = false }
+    devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.110-GTNH:dev") { transitive = false }
     devOnlyNonPublishable("com.github.GTNewHorizons:waila:1.19.30:dev") { transitive = false }
     devOnlyNonPublishable("com.github.GTNewHorizons:ForestryMC:4.11.30:dev") { transitive = false }
     devOnlyNonPublishable("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
@@ -13,27 +13,27 @@ dependencies {
 
 
     // // debugging tools
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:NewHorizonsCoreMod:2.9.0:dev")
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:NewHorizonsCoreMod:2.9.3:dev")
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:ServerUtilities:2.4.1:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:worldedit-gtnh:v0.0.9:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:WAILAPlugins:0.7.2:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:EnderCore:0.5.14:dev") { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.109-GTNH:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.110-GTNH:dev") { transitive = false }
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:Opis:1.4.8-mapless:dev') { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:GTNHLib:0.11.20:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:GTNHLib:0.11.21:dev") { transitive = false }
     // // QOL/creature comforts
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-994-GTNH:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-997-GTNH:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.5.95-gtnh:dev") { transitive = false }
     // var tasks = project.gradle.startParameter.taskNames
     // if (tasks.contains("runClient17") || tasks.contains("runClient21") || tasks.contains("runClient25")) {
-    //     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Angelica:2.1.47:dev") { transitive = false }
+    //     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Angelica:2.1.49:dev") { transitive = false }
     // }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Hodgepodge:2.7.166:dev") { transitive = false }
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:CoreTweaks:0.3.4.7-GTNH:dev') { transitive = false }
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:StorageDrawers:2.2.26-GTNH:dev') { transitive = false }
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:MouseTweaks:2.5.2-GTNH:dev') { transitive = false }
     // // rendering IF structure in NEI
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:StructureLib:1.4.40:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:StructureLib:1.4.41:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:BlockRenderer6343:1.4.15:dev") { transitive = false }
     // // to check what counts as food
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:AppleCore:3.3.11:dev") { transitive = false }

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
@@ -233,6 +233,7 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
             this.failedChecks = null;
             return false;
         }
+
         // Weeds don't care where you are, they will grow
         if (this.getSeed()
             .getCrop() instanceof CropWeed) {
@@ -240,7 +241,16 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
             return true;
         }
 
-        return !this.isMature() && this.areGrowthRequirementsMet();
+        // Do sporadic growth requirement checks on mature crops to get around things like light level checks failing
+        // on load, and disincentive players from moving around their sub-soil blocks to grow multiple crops without
+        // enough sub-soil blocks.
+        if (isMature()) {
+            if (XSTR.XSTR_INSTANCE.nextBoolean()) this.areGrowthRequirementsMet();
+            return false;
+        }
+
+        // if it's not mature just do a growth req check
+        return this.areGrowthRequirementsMet();
     }
 
     @Override
@@ -510,7 +520,13 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
         if (!this.worldObj.isRemote && this.hasCrop()
             && !this.hasWeed()
             && this.isMature()
-            && this.failedChecks == null) {
+            && (this.failedChecks == null || this.areGrowthRequirementsMet())) {
+            if (this.failedChecks != null) {
+                // double-check growth reqs check when there are failed growth reqs, the return is for growth checking
+                // so we need to look at the failed checks list to see if we missed something.
+                this.areGrowthRequirementsMet();
+                if (this.failedChecks == null) return false;
+            }
             for (IGrowthRequirement req : seed.getCrop()
                 .getGrowthRequirements()) {
                 if (req instanceof MachineOnlyGrowthRequirement) return false;


### PR DESCRIPTION
## Summary
This PR adds a sporadic check for growth reqs of mature crops.

This should prevent issues like when a mature crop that requires a light level to grow loads into a dark area due to time of day, and then becomes unharvestable because its growth and harvest requirements are not updated to reflect the change in time.

https://github.com/user-attachments/assets/60f702d5-e4c0-4f9b-9402-a24abda5ed83

This will have a very minor impact on performance, but it's unavoidable.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
