### PR TITLE
add apples to dark oak drop table

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/CropLoader.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/CropLoader.java
@@ -292,6 +292,7 @@ public class CropLoader {
                 new ItemStack(Blocks.sapling, 1, 5),
                 new ItemStack(Blocks.log2, 1, 1)
             )
+            .addDrop(new ItemStack(Items.apple, 2), 500)
             // roofed/dark forest
             .addLikedBiomes(BiomeDictionary.Type.DENSE, BiomeDictionary.Type.SPOOKY, BiomeDictionary.Type.FOREST)
         );

--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/MutationLoader.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/MutationLoader.java
@@ -286,7 +286,7 @@ public class MutationLoader {
         new CropMutation(BonsaiSpruce, BonsaiOak, Pumpkin)
             .register();
 
-        MutationRegistry.instance.register(BonsaiDarkOak, BROWN, TREE, LEAFY, DARK, WOODEN);
+        MutationRegistry.instance.register(BonsaiDarkOak, BROWN, TREE, LEAFY, DARK, WOODEN, EDIBLE);
         new CropMutation(BonsaiDarkOak, BonsaiSpruce, BonsaiOak)
             .register();
 


### PR DESCRIPTION
## Summary
It also drops apples at the same rate as oak, so I added the drop + food pool to match.
<img width="517" height="393" alt="image" src="https://github.com/user-attachments/assets/007eda54-adfd-4647-baf8-3cd03e3f0d68" />
<img width="511" height="340" alt="image" src="https://github.com/user-attachments/assets/8ad0a4a8-2039-4c88-911b-10ed8dfe233f" />
The NEI pool overflow thing is something I'll be fixing in a seperate pr.

## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
