### PR TITLE
Add missing Postea transformer for GT5u chili pepper.

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/handler/migrations/GT5uMigrations.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/handler/migrations/GT5uMigrations.java
@@ -196,6 +196,7 @@ public abstract class GT5uMigrations {
         ItemStackReplacementManager
             .addSimpleReplacement(gtMetaItem2, 32538, CropsNHItemList.micadiaFlower.get(1), true);
         ItemStackReplacementManager.addSimpleReplacement(gtMetaItem2, 32540, CropsNHItemList.tineTwig.get(1), true);
+        addOreDictItemOnlyReplacement(gtMetaItem2, 32550, "cropChilipepper");
         addOreDictItemOnlyReplacement(gtMetaItem2, 32551, "cropLemon");
         addOreDictItemOnlyReplacement(gtMetaItem2, 32552, "cropTomato");
         ItemStackReplacementManager.addSimpleReplacement(gtMetaItem2, 32553, CropsNHItemList.maxTomato.get(1), true);


### PR DESCRIPTION
## Summary
The title says it all. Seems like I missed it for a while.

Tested with the cropsNH migration test world, it's in the right-most chest.

[Crops Migration Test World - from exp 80.zip](https://github.com/user-attachments/files/29675138/Crops.Migration.Test.World.-.from.exp.80.zip)

CI will fail because Eclipse is down; the build should succeed.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
  - Daily 609
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)

