### PR TITLE
Plumbilia should never have been in the reed group.

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/MutationLoader.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/MutationLoader.java
@@ -632,7 +632,7 @@ public class MutationLoader {
             .machineOnly()
             .register();
 
-        MutationRegistry.instance.register(Plumbilia, METALLIC, LEAD, REED, DENSE);
+        MutationRegistry.instance.register(Plumbilia, METALLIC, LEAD, DENSE, TENDRILLY);
         new CropMutation(Plumbilia, Coppon, Withereed)
             .register();
 


### PR DESCRIPTION
## Summary

Tendrilly or flower works much better.
<img width="243" height="252" alt="image" src="https://github.com/user-attachments/assets/84dd1796-9a70-4a03-ad63-87021f6e9b86" /> <img width="257" height="252" alt="image" src="https://github.com/user-attachments/assets/088e3de4-13ec-433c-ac41-88ce1abeeb4d" /> <img width="252" height="274" alt="image" src="https://github.com/user-attachments/assets/5772567b-1f4c-4475-a81f-37d46e2295d5" />


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
  - No AI used.
