### PR TITLE
Add crop sounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Here's a small summary of the things Crops NH does to improve over its predecess
 - It more effectively integrates itself into the GTNH modpack, without compromising its careful balance.
 - It completely removes the need to rely on obscure black boxes such as an OpenComputers robot to use crops.
 
+The mod uses MCLib's AssetDirector module to download assets from Mojang's servers.
+Check [its wiki page](https://github.com/makamys/MCLib/wiki/AssetDirector) for more information.
+
 # FAQ
 
 ## Is Crops NH supported outside of the GTNH modpack?

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -13,6 +13,9 @@ dependencies {
     devOnlyNonPublishable("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
     devOnlyNonPublishable('com.github.GTNewHorizons:Backhand:1.8.11:dev') { transitive = false }
     devOnlyNonPublishable('com.github.GTNewHorizons:FindIt:1.4.3:dev') { transitive = false }
+    shadowImplementation('com.github.makamys:MCLib:0.3.7.8') {
+        exclude group: "codechicken"
+    }
 
     // // optional runtime dependencies, you'll want to copy over the full pack configs to your dev env or else it will crash.
     // // debugging tools

--- a/gradle.properties
+++ b/gradle.properties
@@ -133,7 +133,7 @@ forceEnableMixins = false
 
 # If enabled, you may use 'shadowCompile' for dependencies. They will be integrated into your jar. It is your
 # responsibility to check the license and request permission for distribution if required.
-usesShadowedDependencies = false
+usesShadowedDependencies = true
 
 # If disabled, won't remove unused classes from shadowed dependencies. Some libraries use reflection to access
 # their own classes, making the minimization unreliable.

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -25,4 +25,5 @@ repositories {
             includeGroup('net.glease')
         }
     }
+    maven { url 'https://jitpack.io' }
 }

--- a/src/main/java/com/gtnewhorizon/cropsnh/CropsNH.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/CropsNH.java
@@ -5,6 +5,7 @@ import com.gtnewhorizon.cropsnh.compatibility.TiC.TiCCompatHandler;
 import com.gtnewhorizon.cropsnh.compatibility.extrautils.ExUWateringCanHandler;
 import com.gtnewhorizon.cropsnh.compatibility.findit.FindItCompatHandler;
 import com.gtnewhorizon.cropsnh.compatibility.forestry.ForestryCompatHandler;
+import com.gtnewhorizon.cropsnh.compatibility.mclib.MCLibCompatHandler;
 import com.gtnewhorizon.cropsnh.compatibility.waila.WailaRegistry;
 import com.gtnewhorizon.cropsnh.farming.registries.MutationRegistry;
 import com.gtnewhorizon.cropsnh.handler.ConfigurationHandler;
@@ -35,6 +36,7 @@ import com.gtnewhorizon.gtnhlib.chat.ChatComponentCustomRegistry;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.SidedProxy;
+import cpw.mods.fml.common.event.FMLConstructionEvent;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLLoadCompleteEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
@@ -73,6 +75,11 @@ public class CropsNH {
 
     @SidedProxy(clientSide = Reference.CLIENT_PROXY_CLASS, serverSide = Reference.SERVER_PROXY_CLASS)
     public static IProxy proxy;
+
+    @Mod.EventHandler
+    public static void construct(FMLConstructionEvent event) {
+        MCLibCompatHandler.onConstruct();
+    }
 
     @Mod.EventHandler
     @SuppressWarnings("unused")

--- a/src/main/java/com/gtnewhorizon/cropsnh/api/ICropStickTile.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/api/ICropStickTile.java
@@ -71,6 +71,16 @@ public interface ICropStickTile {
     void playCrossCropSound();
 
     /**
+     * Plays the sound that should be played when uprooting a crop.
+     */
+    void playHarvestSound();
+
+    /**
+     * Plays the sound that should be played when uprooting a crop.
+     */
+    void playCropRemovalSound();
+
+    /**
      * @return if a plant can be planted here, meaning the crop is empty and is not a cross crop
      */
     boolean canPlantSeed();

--- a/src/main/java/com/gtnewhorizon/cropsnh/api/ICropStickTile.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/api/ICropStickTile.java
@@ -66,19 +66,34 @@ public interface ICropStickTile {
     void setCrossCrop(boolean status);
 
     /**
-     * Plays the cross-crop placement and removal noise.
+     * Plays the sound for adding or removing cross-crop sticks.
      */
     void playCrossCropSound();
 
     /**
-     * Plays the sound that should be played when uprooting a crop.
+     * Plays the sound for breaking the block.
+     */
+    void playBreakingSound();
+
+    /**
+     * Plays the sound for harvesting a crop.
      */
     void playHarvestSound();
 
     /**
-     * Plays the sound that should be played when uprooting a crop.
+     * Plays the sound for removing a crop.
      */
     void playCropRemovalSound();
+
+    /**
+     * Plays the sound for planting a crop.
+     */
+    void playPlantingSound();
+
+    /**
+     * Plays the sound for fertilizing a crop.
+     */
+    void playFertilizationSound();
 
     /**
      * @return if a plant can be planted here, meaning the crop is empty and is not a cross crop

--- a/src/main/java/com/gtnewhorizon/cropsnh/compatibility/mclib/MCLibCompatHandler.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/compatibility/mclib/MCLibCompatHandler.java
@@ -1,0 +1,17 @@
+package com.gtnewhorizon.cropsnh.compatibility.mclib;
+
+import makamys.mclib.core.MCLib;
+import makamys.mclib.ext.assetdirector.ADConfig;
+import makamys.mclib.ext.assetdirector.AssetDirectorAPI;
+
+public class MCLibCompatHandler {
+
+    public static void onConstruct() {
+        MCLib.init();
+        ADConfig config = new ADConfig();
+        config.addSoundEvent("1.21", "item.crop.plant", "block");
+        config.addSoundEvent("1.21", "block.crop.break", "block");
+        config.addSoundEvent("1.21", "item.bone_meal.use", "block");
+        AssetDirectorAPI.register(config);
+    }
+}

--- a/src/main/java/com/gtnewhorizon/cropsnh/items/tools/ItemSpadeNH.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/items/tools/ItemSpadeNH.java
@@ -162,6 +162,7 @@ public abstract class ItemSpadeNH extends ItemTool
                 cropTE.dropItem(CropsNHUtils.getWeedDrop(1));
             }
             cropTE.clear();
+            cropTE.playCropRemovalSound();
             return true;
         }
 

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
@@ -516,8 +516,33 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
             ((double) this.yCoord + 0.5d),
             ((double) this.zCoord + 0.5d),
             Blocks.planks.stepSound.func_150496_b(),
-            (Blocks.planks.stepSound.getVolume() + 1.0f) / 2.0f,
+            Blocks.planks.stepSound.getVolume() * 0.5f,
             Blocks.planks.stepSound.getPitch() * 0.8f);
+    }
+
+    @Override
+    public void playHarvestSound() {
+        Block.SoundType breakSound = Blocks.wheat.stepSound;
+        this.worldObj.playSoundEffect(
+            ((double) this.xCoord + 0.5d),
+            ((double) this.yCoord + 0.5d),
+            ((double) this.zCoord + 0.5d),
+            breakSound.func_150496_b(),
+            // a lot quieter to not deafen players with things like TiC scythes that harvest multiple crops at once.
+            breakSound.getVolume() * 0.25f,
+            breakSound.getPitch() * 0.8f);
+    }
+
+    @Override
+    public void playCropRemovalSound() {
+        Block.SoundType breakSound = Blocks.wheat.stepSound;
+        this.worldObj.playSoundEffect(
+            ((double) this.xCoord + 0.5d),
+            ((double) this.yCoord + 0.5d),
+            ((double) this.zCoord + 0.5d),
+            breakSound.func_150496_b(),
+            breakSound.getVolume() * 0.5f,
+            breakSound.getPitch() * 0.8f);
     }
 
     // endregion seed planting
@@ -669,6 +694,9 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
         // remove the crop if we are doing so.
         if (isRemovingCrop) {
             this.clear();
+            this.playCropRemovalSound();
+        } else {
+            this.playHarvestSound();
         }
 
         // crop was either harvested or removed.

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
@@ -511,38 +511,44 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
 
     @Override
     public void playCrossCropSound() {
-        this.worldObj.playSoundEffect(
-            ((double) this.xCoord + 0.5d),
-            ((double) this.yCoord + 0.5d),
-            ((double) this.zCoord + 0.5d),
-            Blocks.planks.stepSound.func_150496_b(),
-            Blocks.planks.stepSound.getVolume() * 0.5f,
-            Blocks.planks.stepSound.getPitch() * 0.8f);
+        Block.SoundType sound = Blocks.planks.stepSound;
+        this.playSoundEffect(sound.func_150496_b(), sound.getVolume() * 0.5f, sound.getPitch() * 0.5f);
+    }
+
+    @Override
+    public void playBreakingSound() {
+        Block.SoundType sound = CropsNHBlocks.blockCropSticks.stepSound;
+        this.playSoundEffect(sound.func_150496_b(), sound.getVolume(), sound.getPitch());
     }
 
     @Override
     public void playHarvestSound() {
-        Block.SoundType breakSound = Blocks.wheat.stepSound;
-        this.worldObj.playSoundEffect(
-            ((double) this.xCoord + 0.5d),
-            ((double) this.yCoord + 0.5d),
-            ((double) this.zCoord + 0.5d),
-            breakSound.func_150496_b(),
-            // a lot quieter to not deafen players with things like TiC scythes that harvest multiple crops at once.
-            breakSound.getVolume() * 0.25f,
-            breakSound.getPitch() * 0.8f);
+        this.playSoundEffect("minecraft_1.21:block.crop.break", 0.5f, XSTR.XSTR_INSTANCE.nextFloat() * 0.1f + 0.95f);
     }
 
     @Override
     public void playCropRemovalSound() {
-        Block.SoundType breakSound = Blocks.wheat.stepSound;
+        this.playSoundEffect("minecraft_1.21:block.crop.break", 1.0f, XSTR.XSTR_INSTANCE.nextFloat() * 0.1f + 0.95f);
+    }
+
+    @Override
+    public void playPlantingSound() {
+        this.playSoundEffect("minecraft_1.21:item.crop.plant", 1.0f, XSTR.XSTR_INSTANCE.nextFloat() * 0.1f + 0.95f);
+    }
+
+    @Override
+    public void playFertilizationSound() {
+        this.playSoundEffect("minecraft_1.21:item.bone_meal.use", 1.0f, XSTR.XSTR_INSTANCE.nextFloat() * 0.1f + 0.95f);
+    }
+
+    private void playSoundEffect(String soundId, float volume, float pitch) {
         this.worldObj.playSoundEffect(
             ((double) this.xCoord + 0.5d),
             ((double) this.yCoord + 0.5d),
             ((double) this.zCoord + 0.5d),
-            breakSound.func_150496_b(),
-            breakSound.getVolume() * 0.5f,
-            breakSound.getPitch() * 0.8f);
+            soundId,
+            volume,
+            pitch);
     }
 
     // endregion seed planting
@@ -1323,6 +1329,7 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
                     if (!player.capabilities.isCreativeMode) {
                         heldItem.stackSize--;
                     }
+                    this.playFertilizationSound();
                     return true;
                 }
             }
@@ -1332,6 +1339,7 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
                 if (!player.capabilities.isCreativeMode) {
                     heldItem.stackSize--;
                 }
+                this.playPlantingSound();
                 // run a check to see if the growth reqs are met
                 this.areGrowthRequirementsMet();
                 return true;
@@ -1497,7 +1505,12 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
 
         // only on living entities plz
         if (this.canTrample() && (this.shouldTrampleFromRunning(entity) || this.shouldTrampleFromFalling(entity))) {
+            boolean hadCrop = this.hasCrop();
             this.breakCropStick(true);
+            if (hadCrop) {
+                this.playCropRemovalSound();
+            }
+            this.playBreakingSound();
             return;
         }
 

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
@@ -511,7 +511,7 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
 
     @Override
     public void playCrossCropSound() {
-        Block.SoundType sound = Blocks.planks.stepSound;
+        Block.SoundType sound = CropsNHBlocks.blockCropSticks.stepSound;
         this.playSoundEffect(sound.func_150496_b(), sound.getVolume() * 0.5f, sound.getPitch() * 0.5f);
     }
 


### PR DESCRIPTION
## Summary
This PR adds a few sound events to common crop interactions and adds an MCLib dependency to load sounds from future versions. The readme has been updated to mention MCLib for good measure.
- Harvesting a crop (1.21 block.crop.break at a lower volume via MCLib)
  - Also plays when removing weeds with a spade.
- Removing a planted crop. (1.21 block.crop.break via MCLib)
  - Also plays when trampling a crop.
- Applying fertilizer. (1.21 item.bone_meal.use via MCLib)
- Planting a crop (1.21 item.crop.plant via MCLib)

Removing, Harvesting, Fertilizing

https://github.com/user-attachments/assets/9fcdb8e0-07c5-4738-9943-c51e63db7ccb

Planting a crop noise

https://github.com/user-attachments/assets/275fba08-af2d-41e7-a0c6-0a7413087235

Resolves #198 

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
  - No AI used.
