### PR TITLE
Remove Gaia Wart's food relation and re-add radiation reduction.

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/compatibility/ic2/IC2CompatHandler.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/compatibility/ic2/IC2CompatHandler.java
@@ -1,0 +1,31 @@
+package com.gtnewhorizon.cropsnh.compatibility.ic2;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.potion.PotionEffect;
+
+import ic2.core.IC2Potion;
+
+public class IC2CompatHandler {
+
+    /**
+     * Reduces the duration of the radiation effect on a player by the given duration.
+     *
+     * @param player    The player to reduce the radiation from.
+     * @param reduction How many seconds to take away from the effect.
+     */
+    public static void reduceRadiationTimer(EntityPlayer player, int reduction) {
+        PotionEffect effect = player.getActivePotionEffect(IC2Potion.radiation);
+        // Abort if player isn't radiated
+        if (effect == null) return;
+        // No matter what we are removing it anyway to update it
+        player.removePotionEffect(effect.getPotionID());
+        // If there is some time remaining, update the timer.
+        int remaining = effect.getDuration() - 600;
+        if (remaining > 0) {
+            PotionEffect newEffect = new PotionEffect(effect.getPotionID(), remaining, effect.getAmplifier());
+            // I know IC2 has them built in via it's potion class, but better use what ever was there for consistency.
+            newEffect.setCurativeItems(newEffect.getCurativeItems());
+            player.addPotionEffect(newEffect);
+        }
+    }
+}

--- a/src/main/java/com/gtnewhorizon/cropsnh/items/produce/ItemGaiaWart.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/items/produce/ItemGaiaWart.java
@@ -3,8 +3,9 @@ package com.gtnewhorizon.cropsnh.items.produce;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.EnumAction;
 import net.minecraft.item.EnumRarity;
-import net.minecraft.item.ItemFood;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.Potion;
 import net.minecraft.world.World;
@@ -16,13 +17,10 @@ import com.gtnewhorizon.cropsnh.utility.RegisterHelper;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-public class ItemGaiaWart extends ItemFood {
+public class ItemGaiaWart extends Item {
 
     public ItemGaiaWart() {
-        super(0, 1.0f, false);
-        this.setAlwaysEdible();
         this.setCreativeTab(CreativeTabs.tabFood);
-        this.setMaxStackSize(64);
         RegisterHelper.registerItem(this, Names.Objects.gaiaWart);
     }
 
@@ -32,8 +30,24 @@ public class ItemGaiaWart extends ItemFood {
     }
 
     @Override
-    public ItemStack onEaten(ItemStack itemstack, World world, EntityPlayer player) {
-        --itemstack.stackSize;
+    public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
+        player.setItemInUse(stack, this.getMaxItemUseDuration(stack));
+        return stack;
+    }
+
+    @Override
+    public int getMaxItemUseDuration(ItemStack stack) {
+        return 32;
+    }
+
+    @Override
+    public EnumAction getItemUseAction(ItemStack stack) {
+        return EnumAction.eat;
+    }
+
+    @Override
+    public ItemStack onEaten(ItemStack stack, World world, EntityPlayer player) {
+        --stack.stackSize;
         world.playSoundAtEntity(player, "random.burp", 0.5f, world.rand.nextFloat() * 0.1f + 0.9f);
         player.removePotionEffect(Potion.confusion.id);
         player.removePotionEffect(Potion.digSlowdown.id);
@@ -45,7 +59,7 @@ public class ItemGaiaWart extends ItemFood {
         player.removePotionEffect(Potion.wither.id);
         // TODO: REIMPLEMENT RADIATION REDUCTION ONCE NUCLEAR HORIZONS IS IMPLEMENTED
         // should reduce effect duration by 600
-        return itemstack;
+        return stack;
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizon/cropsnh/items/produce/ItemGaiaWart.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/items/produce/ItemGaiaWart.java
@@ -13,14 +13,19 @@ import net.minecraft.potion.Potion;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
+import com.gtnewhorizon.cropsnh.compatibility.ic2.IC2CompatHandler;
 import com.gtnewhorizon.cropsnh.reference.Names;
 import com.gtnewhorizon.cropsnh.reference.Reference;
 import com.gtnewhorizon.cropsnh.utility.RegisterHelper;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import gregtech.api.enums.Mods;
 
 public class ItemGaiaWart extends Item {
+
+    /** How much to reduce radiation effects by when eaten. */
+    private static final int RADIATION_REDUCTION = 30 * 20;
 
     public ItemGaiaWart() {
         this.setCreativeTab(CreativeTabs.tabFood);
@@ -66,8 +71,11 @@ public class ItemGaiaWart extends Item {
         player.removePotionEffect(Potion.blindness.id);
         player.removePotionEffect(Potion.poison.id);
         player.removePotionEffect(Potion.wither.id);
-        // TODO: REIMPLEMENT RADIATION REDUCTION ONCE NUCLEAR HORIZONS IS IMPLEMENTED
-        // should reduce effect duration by 600
+        // reduces radiation effects by 30 seconds (600 ticks)
+        if (Mods.IndustrialCraft2.isModLoaded()) {
+            IC2CompatHandler.reduceRadiationTimer(player, RADIATION_REDUCTION);
+        }
+        // TODO: ADD NUCLEAR HORIZONS GAIA WART COMPAT WHEN IT'S READY
         return stack;
     }
 

--- a/src/main/java/com/gtnewhorizon/cropsnh/items/produce/ItemGaiaWart.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/items/produce/ItemGaiaWart.java
@@ -1,5 +1,7 @@
 package com.gtnewhorizon.cropsnh.items.produce;
 
+import java.util.List;
+
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
@@ -8,6 +10,7 @@ import net.minecraft.item.EnumRarity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.Potion;
+import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
 import com.gtnewhorizon.cropsnh.reference.Names;
@@ -22,6 +25,12 @@ public class ItemGaiaWart extends Item {
     public ItemGaiaWart() {
         this.setCreativeTab(CreativeTabs.tabFood);
         RegisterHelper.registerItem(this, Names.Objects.gaiaWart);
+    }
+
+    @SideOnly(Side.CLIENT)
+    @SuppressWarnings("unchecked")
+    public void addInformation(ItemStack stack, EntityPlayer player, List list, boolean flag) {
+        list.add(StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.item." + Names.Objects.gaiaWart));
     }
 
     @SideOnly(value = Side.CLIENT)

--- a/src/main/resources/assets/cropsnh/lang/en_US.lang
+++ b/src/main/resources/assets/cropsnh/lang/en_US.lang
@@ -115,6 +115,7 @@ cropsnh_tooltip.genericSeed.mustUseBreederMachine=Can only be bred using a crop 
 cropsnh_tooltip.item.plantLens=Inspects crops
 cropsnh_tooltip.item.spade=Removes weeds and drops seeds when harvesting mature crops
 cropsnh_tooltip.item.reinforcedSpade=Removes weeds and drops more seeds when harvesting mature crops
+cropsnh_tooltip.item.gaiaWart=Removes most negative status effects when eaten
 # the color coding here can only be done via waila because the chat component handling of formatted strings is ehh bad 
 cropsnh_tooltip.waila.cropStick.failedReq=§c%1$s§r
 cropsnh_tooltip.waila.cropStick.progressBar.scanned=%1$s / %2$s (%3$,.1f%%)


### PR DESCRIPTION
## Summary
- Resolves #207, a long-standing bug that caused the terra wart to appear to replenish hunger and be affected by mods such as nutrition and spice of life.
- Adds a helpful tooltip that tells players what it does.
- Reduces the duration of the IC2 radiation effect by 30s, like Terrawart did, since Nuclear Horizons isn't a part of the 2.9 release of GTNH.

https://github.com/user-attachments/assets/b7ae77e3-549a-42a8-bc14-a018243bbff8

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
  - No AI used.
