### PR TITLE
Add base power cost to seedbed tooltip

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/blocks/BlockSeedBed.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/blocks/BlockSeedBed.java
@@ -19,6 +19,7 @@ import com.gtnewhorizon.cropsnh.tileentity.singleblock.MTECropManager;
 import com.gtnewhorizon.cropsnh.utility.CropsNHUtils;
 
 import cpw.mods.fml.common.LoaderException;
+import gregtech.api.enums.GTValues;
 import gregtech.api.enums.VoltageIndex;
 import gregtech.api.util.tooltip.TooltipHelper;
 
@@ -89,6 +90,10 @@ public class BlockSeedBed extends CropsNHBlockIndustrialFarmTiredComponent {
         return aTier * HARVEST_ROUND_BONUS;
     }
 
+    public static long getBaseEUt(int tier) {
+        return GTValues.VP[tier];
+    }
+
     public void addInformation(ItemStack aStack, EntityPlayer aPlayer, List<String> aTooltip,
         boolean aAdvancedTooltips) {
         super.addInformation(aStack, aPlayer, aTooltip, aAdvancedTooltips);
@@ -101,32 +106,37 @@ public class BlockSeedBed extends CropsNHBlockIndustrialFarmTiredComponent {
         aTooltip.add(
             StatCollector.translateToLocalFormatted(
                 Reference.MOD_ID + "_tooltip.seedBed.1",
-                TooltipHelper.parallelText(getCapacity(tMeta))));
+                TooltipHelper.euRateText(getBaseEUt(tMeta)),
+                TooltipHelper.voltageTierText(tMeta, false)));
         aTooltip.add(
             StatCollector.translateToLocalFormatted(
                 Reference.MOD_ID + "_tooltip.seedBed.2",
-                TooltipHelper.fluidText(getWaterConsumption(tMeta))));
+                TooltipHelper.parallelText(getCapacity(tMeta))));
         aTooltip.add(
             StatCollector.translateToLocalFormatted(
                 Reference.MOD_ID + "_tooltip.seedBed.3",
+                TooltipHelper.fluidText(getWaterConsumption(tMeta))));
+        aTooltip.add(
+            StatCollector.translateToLocalFormatted(
+                Reference.MOD_ID + "_tooltip.seedBed.4",
                 TooltipHelper.fluidText(getFertilizerConsumption(tMeta))));
         if (aAdvancedTooltips) {
             aTooltip.add(
                 StatCollector
-                    .translateToLocalFormatted(Reference.MOD_ID + "_tooltip.seedBed.4.adv", roundIncreaseText));
+                    .translateToLocalFormatted(Reference.MOD_ID + "_tooltip.seedBed.5.adv", roundIncreaseText));
         } else {
             aTooltip.add(
-                StatCollector.translateToLocalFormatted(Reference.MOD_ID + "_tooltip.seedBed.4", roundIncreaseText));
+                StatCollector.translateToLocalFormatted(Reference.MOD_ID + "_tooltip.seedBed.5", roundIncreaseText));
         }
 
         int length = getMultiLength(tMeta);
         String lengthText = TooltipHelper.tierText(formatNumber(length));
         if (length == 1) {
             aTooltip.add(
-                StatCollector.translateToLocalFormatted(Reference.MOD_ID + "_tooltip.seedBed.5.single", lengthText));
+                StatCollector.translateToLocalFormatted(Reference.MOD_ID + "_tooltip.seedBed.6.single", lengthText));
         } else {
             aTooltip.add(
-                StatCollector.translateToLocalFormatted(Reference.MOD_ID + "_tooltip.seedBed.5.plural", lengthText));
+                StatCollector.translateToLocalFormatted(Reference.MOD_ID + "_tooltip.seedBed.6.plural", lengthText));
         }
 
     }

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
@@ -594,7 +594,7 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
     }
 
     private long getPowerUsage() {
-        long basePower = GTValues.VP[this.mUpgradeTier];
+        long basePower = BlockSeedBed.getBaseEUt(this.mUpgradeTier);
         long powerUsage = basePower;
         if (this.mEnvironmentalEnhancementUnitCount > 0) {
             powerUsage += (long) (basePower * BlockEnvironmentalEnhancementUnit.BASE_POWER_INCREASE

--- a/src/main/resources/assets/cropsnh/lang/en_US.lang
+++ b/src/main/resources/assets/cropsnh/lang/en_US.lang
@@ -284,7 +284,7 @@ cropsnh_tooltip.industrialFarm.name=Industrial Farm
 cropsnh_tooltip.industrialFarm.machineType=Industrial Crop Cultivator, IF
 cropsnh_tooltip.industrialFarm.0=Grows crops at an industrial scale
 # separator
-cropsnh_tooltip.industrialFarm.1=The §blength§7 of the machine depends on the §ctier§7 of the §fSeed Bed§7
+cropsnh_tooltip.industrialFarm.1=The §blength§7 and §bbase power cost§7 of the machine depends on the §ctier§7 of the §fSeed Bed§7
 cropsnh_tooltip.industrialFarm.2=The §ctier§7 of the §fupgrades§7 must match the §ctier§7 of the §fSeed Bed§7
 cropsnh_tooltip.industrialFarm.structure.seedBed=Seed Bed
 cropsnh_tooltip.industrialFarm.structure.upgrades.name=IF Upgrade Unit
@@ -340,14 +340,15 @@ cropsnh_tooltip.industrialFarm.scanner.6=Nutrient Score: §e%1$s§r out of §e%2
 
 # Seed Bed
 cropsnh_tooltip.seedBed.name=Seed Bed (%1$s)
-cropsnh_tooltip.seedBed.0=Determines the §ctier§7 of the Industrial Farm
-cropsnh_tooltip.seedBed.1=Seed Capacity: %1$s
-cropsnh_tooltip.seedBed.2=Requires %1$s of water per cycle
-cropsnh_tooltip.seedBed.3=Optionally uses %1$s of fertilizer per cycle
-cropsnh_tooltip.seedBed.4=Increases number of drops by %1$s
-cropsnh_tooltip.seedBed.4.adv=Increases number of drops by %1$s (additive)
-cropsnh_tooltip.seedBed.5.single=Farm must have exactly %1$s middle slice
-cropsnh_tooltip.seedBed.5.plural=Farm must have exactly %1$s middle slices
+cropsnh_tooltip.seedBed.0=Determines the §ctier§7 and §cbase power cost§7 of the Industrial Farm
+cropsnh_tooltip.seedBed.1=Base Power Cost: %1$s (%2$s)
+cropsnh_tooltip.seedBed.2=Seed Capacity: %1$s
+cropsnh_tooltip.seedBed.3=Requires %1$s of water per cycle
+cropsnh_tooltip.seedBed.4=Optionally uses %1$s of fertilizer per cycle
+cropsnh_tooltip.seedBed.5=Increases number of drops by %1$s
+cropsnh_tooltip.seedBed.5.adv=Increases number of drops by %1$s (additive)
+cropsnh_tooltip.seedBed.6.single=Farm must have exactly %1$s middle slice
+cropsnh_tooltip.seedBed.6.plural=Farm must have exactly %1$s middle slices
 cropsnh.seedBed.2.name=Seed Bed (MV)
 cropsnh.seedBed.3.name=Seed Bed (HV)
 cropsnh.seedBed.4.name=Seed Bed (EV)


### PR DESCRIPTION
## Summary
This PR adds a line to the seed beds tooltip indicating their base power usage and adds a note to the industrial farm's tooltip about seed beds determining the base power cost.

https://github.com/user-attachments/assets/e3bb9be9-178c-4b57-8879-4621217a72f0

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
  - No AI used
