### PR TITLE
Boot protection system (For 2.9, Missing feature parity)

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/CropsNH.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/CropsNH.java
@@ -125,9 +125,9 @@ public class CropsNH {
         CropLoader.postInit();
         MutationLoader.postInit();
         AspectLoader.postInit();
-        GTRecipeLoader.PostInit();
+        GTRecipeLoader.postInit();
         MigrationHandler.postInit();
-        ForestryCompatHandler.onPostInit();
+        ForestryCompatHandler.postInit();
         ExUWateringCanHandler.postInit();
         FindItCompatHandler.postInit();
 

--- a/src/main/java/com/gtnewhorizon/cropsnh/CropsNH.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/CropsNH.java
@@ -15,6 +15,7 @@ import com.gtnewhorizon.cropsnh.init.CropsNHBlocks;
 import com.gtnewhorizon.cropsnh.init.CropsNHFluids;
 import com.gtnewhorizon.cropsnh.init.CropsNHItems;
 import com.gtnewhorizon.cropsnh.loaders.AspectLoader;
+import com.gtnewhorizon.cropsnh.loaders.BootProtectionLoader;
 import com.gtnewhorizon.cropsnh.loaders.CropLoader;
 import com.gtnewhorizon.cropsnh.loaders.FertilizerLoader;
 import com.gtnewhorizon.cropsnh.loaders.GTRecipeLoader;
@@ -126,6 +127,7 @@ public class CropsNH {
         MutationLoader.postInit();
         AspectLoader.postInit();
         GTRecipeLoader.postInit();
+        BootProtectionLoader.postInit();
         MigrationHandler.postInit();
         ForestryCompatHandler.postInit();
         ExUWateringCanHandler.postInit();

--- a/src/main/java/com/gtnewhorizon/cropsnh/api/IBootProtectionRegistry.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/api/IBootProtectionRegistry.java
@@ -1,0 +1,39 @@
+package com.gtnewhorizon.cropsnh.api;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+public interface IBootProtectionRegistry {
+
+    /**
+     * Registers a handler that provides protection to crop contact effects.
+     *
+     * @param item    The item for the boots.
+     * @param meta    The meta value of the boots or {@link net.minecraftforge.oredict.OreDictionary#WILDCARD_VALUE} to
+     *                ignore meta values.
+     * @param handler The handler that determines the amount of protection provided by the item.
+     */
+    void register(final Item item, final int meta, final ICropsNHBootProtectionHandler handler);
+
+    /**
+     * Registers a handler that provides protection to crop contact effects except when a handler already exists.
+     *
+     * @param item    The item for the boots.
+     * @param meta    The meta value of the boots or {@link net.minecraftforge.oredict.OreDictionary#WILDCARD_VALUE} to
+     *                ignore meta values.
+     * @param handler The handler that determines the amount of protection provided by the item
+     * @return True if the handler was registered.
+     */
+    boolean registerIfAbsent(final Item item, final int meta, final ICropsNHBootProtectionHandler handler);
+
+    /**
+     * Gets the protection value provided by a given set of boots.
+     *
+     * @param stack  The stack of boots being worn.
+     * @param entity The entity wearing the boots.
+     * @param cropTE The crop being collided with.
+     * @return A value between 0 and 1 indicating how much protection was provided by the boots.
+     */
+    float getProtection(final ItemStack stack, final EntityLivingBase entity, final ICropStickTile cropTE);
+}

--- a/src/main/java/com/gtnewhorizon/cropsnh/api/ICropStickTile.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/api/ICropStickTile.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 
@@ -338,6 +339,12 @@ public interface ICropStickTile {
      * @param entity The entity that collided with the block.
      */
     void onEntityCollision(Entity entity);
+
+    /**
+     * @param entity The entity colliding with the TE.
+     * @return The boot protection value of the entity's boots.
+     */
+    float getBootProtection(EntityLivingBase entity);
 
     /**
      * Fired when the neighbour blocks change but the crop sticks don't break.

--- a/src/main/java/com/gtnewhorizon/cropsnh/api/ICropsNHBootProtectionHandler.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/api/ICropsNHBootProtectionHandler.java
@@ -1,0 +1,27 @@
+package com.gtnewhorizon.cropsnh.api;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+
+import org.jetbrains.annotations.NotNull;
+
+public interface ICropsNHBootProtectionHandler {
+
+    /**
+     * Checks if a given stack can protect the player.
+     *
+     * @param stack  The stack of boots being worn by the player
+     * @param entity The entity wearing the boots.
+     * @param cropTE The crop stick containing the crop the entity is colliding with.
+     *
+     * @return a value ranging from 0.0 to 1.0 that define the protection percentage given by the item.
+     */
+    float getProtection(@NotNull final ItemStack stack, @NotNull final EntityLivingBase entity,
+        @NotNull final ICropStickTile cropTE);
+
+    /**
+     * @return The string used to display the boot protection value when dumping handler in nei.
+     */
+    String getDumpText();
+
+}

--- a/src/main/java/com/gtnewhorizon/cropsnh/compatibility/NEI/NEIConfig.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/compatibility/NEI/NEIConfig.java
@@ -2,6 +2,7 @@ package com.gtnewhorizon.cropsnh.compatibility.NEI;
 
 import com.gtnewhorizon.cropsnh.CropsNH;
 import com.gtnewhorizon.cropsnh.compatibility.NEI.dumpers.AlternateSeedDumper;
+import com.gtnewhorizon.cropsnh.compatibility.NEI.dumpers.BootProtectionDumper;
 import com.gtnewhorizon.cropsnh.compatibility.NEI.dumpers.CropRegistryDumper;
 import com.gtnewhorizon.cropsnh.compatibility.NEI.dumpers.DeterministicMutationRegistryDumper;
 import com.gtnewhorizon.cropsnh.compatibility.NEI.dumpers.FertilizerFluidsRegistryDumper;
@@ -46,6 +47,7 @@ public class NEIConfig implements IConfigureNEI {
         API.addOption(new MutationPoolRegistryDumper());
         API.addOption(new SoilRegistryDumper());
         API.addOption(new WeedEXFluidsRegistryDumper());
+        API.addOption(new BootProtectionDumper());
     }
 
     private static void registerNEITabs() {

--- a/src/main/java/com/gtnewhorizon/cropsnh/compatibility/NEI/dumpers/BootProtectionDumper.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/compatibility/NEI/dumpers/BootProtectionDumper.java
@@ -1,0 +1,55 @@
+package com.gtnewhorizon.cropsnh.compatibility.NEI.dumpers;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import com.gtnewhorizon.cropsnh.farming.registries.BootProtectionRegistry;
+import com.gtnewhorizon.cropsnh.reference.Reference;
+
+import codechicken.nei.config.DataDumper;
+
+public class BootProtectionDumper extends DataDumper {
+
+    public BootProtectionDumper() {
+        super("tools.dump." + Reference.MOD_ID + ".bootProtection");
+    }
+
+    @Override
+    public String renderName() {
+        return translateN(this.name);
+    }
+
+    @Override
+    public String modeButtonText() {
+        return "";
+    }
+
+    @Override
+    public String[] header() {
+        return new String[0];
+    }
+
+    @Override
+    public Iterable<String[]> dump(int mode) {
+        return null;
+    }
+
+    @Override
+    public String getFileExtension() {
+        return ".csv";
+    }
+
+    @Override
+    public void dumpTo(File file) throws IOException {
+        PrintWriter w = new PrintWriter(file);
+        w.print(BootProtectionRegistry.instance.dump());
+        w.flush();
+        w.close();
+    }
+
+    @Override
+    public int modeCount() {
+        return 0;
+    }
+}

--- a/src/main/java/com/gtnewhorizon/cropsnh/compatibility/forestry/ForestryCompatHandler.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/compatibility/forestry/ForestryCompatHandler.java
@@ -15,7 +15,7 @@ import forestry.plugins.PluginManager;
 
 public abstract class ForestryCompatHandler {
 
-    public static void onPostInit() {
+    public static void postInit() {
         if (!ModUtils.Forestry.isModLoaded()) return;
         addMultifarmCompat();
     }

--- a/src/main/java/com/gtnewhorizon/cropsnh/crops/material/CropNecrobloom.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/crops/material/CropNecrobloom.java
@@ -4,6 +4,7 @@ import java.awt.Color;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.Potion;
@@ -15,6 +16,7 @@ import com.gtnewhorizon.cropsnh.api.ICropStickTile;
 import com.gtnewhorizon.cropsnh.api.ISeedShape;
 import com.gtnewhorizon.cropsnh.api.SeedShape;
 import com.gtnewhorizon.cropsnh.crops.abstracts.NHCropCard;
+import com.gtnewhorizon.cropsnh.farming.registries.BootProtectionRegistry;
 import com.gtnewhorizon.cropsnh.utility.XSTR;
 
 public class CropNecrobloom extends NHCropCard {
@@ -54,9 +56,26 @@ public class CropNecrobloom extends NHCropCard {
 
     @Override
     public void onEntityCollision(ICropStickTile te, Entity entity) {
-        if (te.isMature() && entity instanceof EntityLivingBase) {
+        if (entity.worldObj.isRemote) return;
+        if (te.isMature() && entity instanceof EntityLivingBase elb) {
+            // creative players don't get affected
+            if ((entity instanceof EntityPlayer && ((EntityPlayer) entity).capabilities.disableDamage)) {
+                return;
+            }
+
+            // check if the entity's boots protect them
+            final float protection = te.getBootProtection(elb);
+            if (protection >= BootProtectionRegistry.FULL_PROTECTION) return;
+
+            // reduce the duration by the multiplier
             int duration = (XSTR.XSTR_INSTANCE.nextInt(10) + 5) * 20;
-            ((EntityLivingBase) entity).addPotionEffect(new PotionEffect(Potion.poison.id, duration, 0));
+            float multiplier = 1 - (protection / BootProtectionRegistry.FULL_PROTECTION);
+            // explicit casting because intellij be dumb
+            duration = (int) (duration * multiplier);
+            if (duration <= 0) return;
+
+            // add potion effect of defined duration
+            elb.addPotionEffect(new PotionEffect(Potion.poison.id, duration, 0));
         }
     }
 }

--- a/src/main/java/com/gtnewhorizon/cropsnh/crops/mobs/CropGoldfish.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/crops/mobs/CropGoldfish.java
@@ -59,6 +59,11 @@ public class CropGoldfish extends NHCropCard {
 
     @Override
     public void onEntityCollision(ICropStickTile crop, Entity entity) {
+        if (entity.worldObj.isRemote) return;
+        // Wearing armored shoes won't reduce the amount of screams.
+        // If anything it should increase them, but I'm not that mean.
+        // Just don't step on em or use an IF and they won't need to scream much ;)
+        // also screaming probably shouldn't be breaking boots.
         if (ConfigurationHandler.goldfishScreamWhenSteppedOn && entity instanceof EntityPlayer
             && crop instanceof TileEntityCropSticks) {
             this.scream((TileEntityCropSticks) crop);

--- a/src/main/java/com/gtnewhorizon/cropsnh/farming/bootprotection/ConstantBootProtectionHandler.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/farming/bootprotection/ConstantBootProtectionHandler.java
@@ -1,0 +1,38 @@
+package com.gtnewhorizon.cropsnh.farming.bootprotection;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.gtnewhorizon.cropsnh.api.ICropStickTile;
+import com.gtnewhorizon.cropsnh.api.ICropsNHBootProtectionHandler;
+import com.gtnewhorizon.cropsnh.utility.DebugHelper;
+
+/**
+ * A boot protection handler that provides a constant protection value.
+ */
+public class ConstantBootProtectionHandler implements ICropsNHBootProtectionHandler {
+
+    /** The protection provided by the boots. */
+    protected final float protection;
+
+    /**
+     * @param protection The protection provided by the boots
+     */
+    public ConstantBootProtectionHandler(float protection) {
+        this.protection = protection;
+    }
+
+    @Override
+    public float getProtection(@NotNull final ItemStack stack, @NotNull final EntityLivingBase entity,
+        @NotNull final ICropStickTile cropTE) {
+        return this.protection;
+    }
+
+    @Override
+    public String getDumpText() {
+        return DebugHelper.makeCSVLine("Type: Constant", String.format("Protection: %1.2f", this.protection));
+    }
+
+}

--- a/src/main/java/com/gtnewhorizon/cropsnh/farming/bootprotection/DamageBootProtectionHandler.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/farming/bootprotection/DamageBootProtectionHandler.java
@@ -1,0 +1,126 @@
+package com.gtnewhorizon.cropsnh.farming.bootprotection;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Vec3;
+import net.minecraft.world.WorldServer;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.gtnewhorizon.cropsnh.api.ICropStickTile;
+import com.gtnewhorizon.cropsnh.api.ICropsNHBootProtectionHandler;
+import com.gtnewhorizon.cropsnh.utility.DebugHelper;
+import com.gtnewhorizon.cropsnh.utility.XSTR;
+
+/**
+ * An abstractable boot protection handler that damages the worn boots.
+ */
+public class DamageBootProtectionHandler implements ICropsNHBootProtectionHandler {
+
+    /** The upper boundary of damage rolls (exclusive). */
+    public static final int DAMAGE_CHANCE_MAX = 100_00;
+
+    /** The amount to damage the item by. */
+    protected final int itemDamage;
+    /** The chance to damage the item when it can take damage. */
+    protected final int damageChance;
+    /** The protection provided by the boots */
+    protected final float protection;
+
+    /**
+     * @param itemDamage   The amount to damage the item by.
+     * @param damageChance The chance to damage the item when it can be damaged.
+     * @param protection   The amount of protection provided by the boots.
+     */
+    public DamageBootProtectionHandler(final int itemDamage, final int damageChance, final float protection) {
+        this.itemDamage = itemDamage;
+        this.damageChance = damageChance;
+        this.protection = protection;
+    }
+
+    @Override
+    public float getProtection(@NotNull final ItemStack stack, @NotNull final EntityLivingBase entity,
+        @NotNull final ICropStickTile cropTE) {
+        if (this.canDamageItem(stack, entity, cropTE)
+            && XSTR.XSTR_INSTANCE.nextInt(DAMAGE_CHANCE_MAX) <= this.damageChance) {
+            makeParticles(entity, stack);
+            this.damageItem(stack, entity, cropTE);
+
+            // if the boots broke make some noise and yeet it from the player's inventory.
+            if (stack.stackSize <= 0) {
+                entity.worldObj.playSoundAtEntity(
+                    entity,
+                    "random.break",
+                    0.8F,
+                    0.8F + entity.getRNG()
+                        .nextFloat() * 0.4F);
+
+                // make sure it's the same stack (ref equal) so we don't nuke a random item by mistake.
+                if (entity.getEquipmentInSlot(1) == stack) {
+                    entity.setCurrentItemOrArmor(1, null);
+                }
+            }
+        }
+        return this.protection;
+    }
+
+    private static void makeParticles(EntityLivingBase ent, ItemStack itemStack) {
+        WorldServer s = (WorldServer) ent.worldObj;
+        Vec3 vec31 = Vec3.createVectorHelper(ent.posX, (ent.posY + 1) - (double) ent.getEyeHeight() / 2, ent.posZ);
+        s.func_147487_a(
+            "iconcrack_" + Item.getIdFromItem(itemStack.getItem()),
+            vec31.xCoord,
+            vec31.yCoord,
+            vec31.zCoord,
+            3,
+            0,
+            0,
+            0,
+            0.1);
+    }
+
+    /**
+     * Checks if an entity's boots can be damaged.
+     *
+     * @implNote does not include the percentage chance to damage the item.
+     *
+     * @param stack  The boots worn by the entity.
+     * @param entity The entity wearing the boots.
+     * @param cropTE The crop stick tile being collided with.
+     * @return True if the entity's boots can be damaged.
+     */
+    public boolean canDamageItem(@NotNull final ItemStack stack, @NotNull final EntityLivingBase entity,
+        @NotNull final ICropStickTile cropTE) {
+        // don't do the damage on the client side
+        if (entity.worldObj.isRemote) return false;
+
+        // don't damage boots of creative players
+        if (entity instanceof EntityPlayer player && player.capabilities.isCreativeMode) return false;
+
+        // Only damage the boots when the player is moving
+        return entity.prevPosX != entity.posX || entity.prevPosY != entity.posY || entity.prevPosZ != entity.posZ;
+    }
+
+    /**
+     * Applies damage to the boots.
+     *
+     * @param stack  The boots to apply damage to.
+     * @param entity The entity wearing the boots.
+     * @param cropTE The crop stick tile being collided with.
+     */
+    public void damageItem(@NotNull final ItemStack stack, @NotNull final EntityLivingBase entity,
+        @NotNull final ICropStickTile cropTE) {
+        stack.damageItem(this.itemDamage, entity);
+    }
+
+    @Override
+    public String getDumpText() {
+        return DebugHelper.makeCSVLine(
+            "Type: item damage",
+            String.format("Protection: %1.2f", this.protection),
+            String.format("Item damage: %d", this.itemDamage),
+            String.format("Item damage chance: %d", this.damageChance));
+    }
+}

--- a/src/main/java/com/gtnewhorizon/cropsnh/farming/registries/BootProtectionRegistry.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/farming/registries/BootProtectionRegistry.java
@@ -1,0 +1,127 @@
+package com.gtnewhorizon.cropsnh.farming.registries;
+
+import java.util.stream.Collectors;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+import com.gtnewhorizon.cropsnh.api.IBootProtectionRegistry;
+import com.gtnewhorizon.cropsnh.api.ICropStickTile;
+import com.gtnewhorizon.cropsnh.api.ICropsNHBootProtectionHandler;
+import com.gtnewhorizon.cropsnh.farming.bootprotection.ConstantBootProtectionHandler;
+import com.gtnewhorizon.cropsnh.utility.CropsNHUtils;
+import com.gtnewhorizon.cropsnh.utility.DebugHelper;
+import com.gtnewhorizon.cropsnh.utility.LogHelper;
+import com.gtnewhorizon.cropsnh.utility.MetaMap;
+
+public class BootProtectionRegistry implements IBootProtectionRegistry {
+
+    /** The value that represents no protection being given. */
+    public static final float NO_PROTECTION = 0.0F;
+    /** The value that represents the point at which all effects should be prevented. */
+    public static final float FULL_PROTECTION = 1.0F;
+    /** A default handler to provide full immunity at base. */
+    public static final ICropsNHBootProtectionHandler FULL_PROTECTION_HANDLER = new ConstantBootProtectionHandler(
+        FULL_PROTECTION);
+
+    /** The main instance for the registry. */
+    public static final BootProtectionRegistry instance = new BootProtectionRegistry();
+
+    /** The map of item -> handler */
+    private final MetaMap<Item, ICropsNHBootProtectionHandler> registry = new MetaMap<>();
+
+    public BootProtectionRegistry() {}
+
+    @Override
+    public void register(final Item item, final int meta, final ICropsNHBootProtectionHandler handler) {
+        if (item == null) {
+            if (CropsNHUtils.shouldPanicIfNullFound()) {
+                throw new IllegalStateException("Attempted to add a null item to a boot protection registry!");
+            } else {
+                try {
+                    throw new Exception("CROPS NH ATTEMPTED TO ADD NULL ITEM TO BOOT PROTECTION REGISTRY");
+                } catch (Exception e) {
+                    LogHelper.warn(e.getMessage());
+                    e.printStackTrace();
+                }
+                return;
+            }
+        }
+        if (handler == null) {
+            throw new IllegalArgumentException("handler cannot be null!s");
+        }
+        this.registry.put(item, meta, handler);
+    }
+
+    @Override
+    public boolean registerIfAbsent(final Item item, final int meta, final ICropsNHBootProtectionHandler handler) {
+        if (item == null) {
+            if (CropsNHUtils.shouldPanicIfNullFound()) {
+                throw new IllegalStateException("Attempted to add a null item to a boot protection registry!");
+            } else {
+                try {
+                    throw new Exception("CROPS NH ATTEMPTED TO ADD NULL ITEM TO BOOT PROTECTION REGISTRY");
+                } catch (Exception e) {
+                    LogHelper.warn(e.getMessage());
+                    e.printStackTrace();
+                }
+                return false;
+            }
+        }
+        if (handler == null) {
+            throw new IllegalArgumentException("handler cannot be null!s");
+        }
+        return this.registry.putIfAbsent(item, meta, handler, false);
+    }
+
+    @Override
+    public float getProtection(final ItemStack stack, final EntityLivingBase entity, final ICropStickTile cropTE) {
+        // invalid items get no protection
+        if (CropsNHUtils.isStackInvalid(stack)) return NO_PROTECTION;
+
+        // no handler, no protection
+        final ICropsNHBootProtectionHandler handler = this.registry
+            .get(stack.getItem(), CropsNHUtils.getItemMeta(stack));
+        if (handler == null) return NO_PROTECTION;
+
+        return handler.getProtection(stack, entity, cropTE);
+    }
+
+    /**
+     * Registers a handler providing full protection while wearing the given boots.
+     *
+     * @param item The item for the boots.
+     * @param meta The meta value of the boots or {@link net.minecraftforge.oredict.OreDictionary#WILDCARD_VALUE} to
+     *             ignore meta values.
+     */
+    public void registerFullProtectionHandler(final Item item, final int meta) {
+        this.register(item, meta, FULL_PROTECTION_HANDLER);
+    }
+
+    /**
+     * Registers a handler providing full protection while wearing the given boots except when a handler already exists.
+     *
+     * @param item The item being worn.
+     * @param meta The meta value of the boots or {@link net.minecraftforge.oredict.OreDictionary#WILDCARD_VALUE} to
+     *             ignore meta values.
+     * @return True if the handler was registered.
+     */
+    public boolean registerFullProtectionHandlerIfAbsent(final Item item, final int meta) {
+        return this.registerIfAbsent(item, meta, FULL_PROTECTION_HANDLER);
+    }
+
+    /**
+     * @return A csv dump of the registry's contents for NEI dump purposes.
+     */
+    public String dump() {
+        return DebugHelper.makeCSVLine("Item", "Handler Type", "Parameters") + System.lineSeparator()
+            + this.registry.getStream()
+                .map(
+                    x -> DebugHelper.makeCSVLine(
+                        DebugHelper.dumpStack(new ItemStack(x.key, 1, x.meta == null ? 0 : x.meta), true)) + ","
+                        + x.value.getDumpText())
+                .collect(Collectors.joining(System.lineSeparator()));
+    }
+
+}

--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/BootProtectionLoader.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/BootProtectionLoader.java
@@ -1,0 +1,177 @@
+package com.gtnewhorizon.cropsnh.loaders;
+
+import net.minecraft.init.Items;
+import net.minecraftforge.oredict.OreDictionary;
+
+import com.gtnewhorizon.cropsnh.api.ICropsNHBootProtectionHandler;
+import com.gtnewhorizon.cropsnh.farming.bootprotection.DamageBootProtectionHandler;
+import com.gtnewhorizon.cropsnh.farming.registries.BootProtectionRegistry;
+import com.gtnewhorizon.cropsnh.utility.ModUtils;
+
+public class BootProtectionLoader {
+
+    public static void postInit() {
+        // general rules:
+        // - if it provides only hazmat and isn't electric: takes damage, immune
+        // - if it provides only hazmat but is electric or provides full space suit protection: no damage, immune
+
+        // TODO: update this when hazmat suit cleanroom happens.
+        // reduce the leather boot protection value when IC2/rubber boots is installed
+        float leatherBootDamageProtection = BootProtectionRegistry.FULL_PROTECTION;
+        if (ModUtils.IndustrialCraft2.isModLoaded()) leatherBootDamageProtection *= 0.75f;
+
+        ICropsNHBootProtectionHandler leatherBootDamageHandler = new DamageBootProtectionHandler(
+            1,
+            1_00,
+            leatherBootDamageProtection);
+
+        ICropsNHBootProtectionHandler defaultBootDamageHandler = new DamageBootProtectionHandler(
+            1,
+            1_00,
+            BootProtectionRegistry.FULL_PROTECTION);
+
+        BootProtectionRegistry.instance
+            .register(Items.leather_boots, OreDictionary.WILDCARD_VALUE, leatherBootDamageHandler);
+
+        if (ModUtils.Avaritia.isModLoaded()) {
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.Avaritia.getItem("Infinity_Shoes"),
+                OreDictionary.WILDCARD_VALUE);
+        }
+        if (ModUtils.BloodMagic.isModLoaded()) {
+            BootProtectionRegistry.instance
+                .registerFullProtectionHandler(ModUtils.BloodMagic.getItem("boundBoots"), OreDictionary.WILDCARD_VALUE);
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.BloodMagic.getItem("boundBootsEarth"),
+                OreDictionary.WILDCARD_VALUE);
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.BloodMagic.getItem("boundBootsFire"),
+                OreDictionary.WILDCARD_VALUE);
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.BloodMagic.getItem("boundBootsWater"),
+                OreDictionary.WILDCARD_VALUE);
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.BloodMagic.getItem("boundBootsWind"),
+                OreDictionary.WILDCARD_VALUE);
+        }
+        if (ModUtils.DraconicEvolution.isModLoaded()) {
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.DraconicEvolution.getItem("draconicBoots"),
+                OreDictionary.WILDCARD_VALUE);
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.DraconicEvolution.getItem("wyvernBoots"),
+                OreDictionary.WILDCARD_VALUE);
+        }
+        if (ModUtils.ElectroMagicTools.isModLoaded()) {
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.ElectroMagicTools.getItem("NanoBootsTraveller"),
+                OreDictionary.WILDCARD_VALUE);
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.ElectroMagicTools.getItem("QuantumBootsTraveller"),
+                OreDictionary.WILDCARD_VALUE);
+        }
+        if (ModUtils.ElectroMagicTools.isModLoaded()) {
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.ElectroMagicTools.getItem("NanoBootsTraveller"),
+                OreDictionary.WILDCARD_VALUE);
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.ElectroMagicTools.getItem("QuantumBootsTraveller"),
+                OreDictionary.WILDCARD_VALUE);
+        }
+        if (ModUtils.EnderIO.isModLoaded()) {
+            BootProtectionRegistry.instance.register(
+                ModUtils.EnderIO.getItem("item.endSteel_boots"),
+                OreDictionary.WILDCARD_VALUE,
+                defaultBootDamageHandler);
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.EnderIO.getItem("item.stellar_boots"),
+                OreDictionary.WILDCARD_VALUE);
+        }
+        if (ModUtils.GalaxySpace.isModLoaded()) {
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.GalaxySpace.getItem("item.spacesuit_boots"),
+                OreDictionary.WILDCARD_VALUE);
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.GalaxySpace.getItem("item.spacesuit_gravityboots"),
+                OreDictionary.WILDCARD_VALUE);
+        }
+        if (ModUtils.GTPlusPlus.isModLoaded()) {
+            // adv rubber boots take damage
+            BootProtectionRegistry.instance.register(
+                ModUtils.GTPlusPlus.getItem("itemArmorRubBootsEx"),
+                OreDictionary.WILDCARD_VALUE,
+                defaultBootDamageHandler);
+        }
+        if (ModUtils.IndustrialCraft2.isModLoaded()) {
+            // rubber boots take damage
+            BootProtectionRegistry.instance.register(
+                ModUtils.IndustrialCraft2.getItem("itemArmorRubBoots"),
+                OreDictionary.WILDCARD_VALUE,
+                defaultBootDamageHandler);
+
+            // nano/quantum boots have full protection
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.IndustrialCraft2.getItem("itemArmorNanoBoots"),
+                OreDictionary.WILDCARD_VALUE);
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.IndustrialCraft2.getItem("itemArmorQuantumBoots"),
+                OreDictionary.WILDCARD_VALUE);
+        }
+        if (ModUtils.Natura.isModLoaded()) {
+            BootProtectionRegistry.instance.register(
+                ModUtils.Natura.getItem("natura.armor.impboots"),
+                OreDictionary.WILDCARD_VALUE,
+                leatherBootDamageHandler);
+        }
+        if (ModUtils.PamsHarvestCraft.isModLoaded()) {
+            BootProtectionRegistry.instance.register(
+                ModUtils.PamsHarvestCraft.getItem("hardenedleatherbootsItem"),
+                OreDictionary.WILDCARD_VALUE,
+                leatherBootDamageHandler);
+        }
+        if (ModUtils.TaintedMagic.isModLoaded()) {
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.TaintedMagic.getItem("ItemVoidwalkerBoots"),
+                OreDictionary.WILDCARD_VALUE);
+        }
+        if (ModUtils.ThaumicBoots.isModLoaded()) {
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.ThaumicBoots.getItem("item.ItemElectricVoid"),
+                OreDictionary.WILDCARD_VALUE);
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.ThaumicBoots.getItem("item.ItemNanoComet"),
+                OreDictionary.WILDCARD_VALUE);
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.ThaumicBoots.getItem("item.ItemNanoMeteor"),
+                OreDictionary.WILDCARD_VALUE);
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.ThaumicBoots.getItem("item.ItemNanoVoid"),
+                OreDictionary.WILDCARD_VALUE);
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.ThaumicBoots.getItem("item.ItemQuantumComet"),
+                OreDictionary.WILDCARD_VALUE);
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.ThaumicBoots.getItem("item.ItemQuantumMeteor"),
+                OreDictionary.WILDCARD_VALUE);
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.ThaumicBoots.getItem("item.ItemQuantumVoid"),
+                OreDictionary.WILDCARD_VALUE);
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.ThaumicBoots.getItem("item.ItemVoidComet"),
+                OreDictionary.WILDCARD_VALUE);
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.ThaumicBoots.getItem("item.ItemVoidMeteor"),
+                OreDictionary.WILDCARD_VALUE);
+        }
+        if (ModUtils.ThaumicTinkerer.isModLoaded()) {
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.ThaumicTinkerer.getItem("ichorclothBootsGem"),
+                OreDictionary.WILDCARD_VALUE);
+        }
+        if (ModUtils.WitchingGadgets.isModLoaded()) {
+            BootProtectionRegistry.instance.registerFullProtectionHandler(
+                ModUtils.WitchingGadgets.getItem("item.WG_PrimordialBoots"),
+                OreDictionary.WILDCARD_VALUE);
+        }
+    }
+}

--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/GTRecipeLoader.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/GTRecipeLoader.java
@@ -43,7 +43,7 @@ import gregtech.api.util.GTUtility;
 
 public abstract class GTRecipeLoader extends BaseGTRecipeLoader {
 
-    public static void PostInit() {
+    public static void postInit() {
         CropRecipes.postInit();
         FertilizerRecipes.postInit();
         CropsPlusPlusRecipes.postInit();

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/TileEntityCropSticks.java
@@ -51,6 +51,7 @@ import com.gtnewhorizon.cropsnh.crops.CropMigrator;
 import com.gtnewhorizon.cropsnh.crops.CropWeed;
 import com.gtnewhorizon.cropsnh.farming.SeedData;
 import com.gtnewhorizon.cropsnh.farming.SeedStats;
+import com.gtnewhorizon.cropsnh.farming.registries.BootProtectionRegistry;
 import com.gtnewhorizon.cropsnh.farming.registries.CropRegistry;
 import com.gtnewhorizon.cropsnh.farming.registries.FertilizerRegistry;
 import com.gtnewhorizon.cropsnh.farming.registries.MutationRegistry;
@@ -1418,6 +1419,7 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
      * @implNote will return false if no crop is planted, it's a weed or a migrator crop
      */
     private boolean canTrample() {
+        if (this.worldObj.isRemote) return false;
         // abort if no crop is planted, it's a weed or a migrator crop
         if (!this.hasCrop() || this.hasWeed() || this.seed.getCrop() instanceof CropMigrator) return false;
         // max resil crops can't be trampled
@@ -1501,7 +1503,7 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
     @Override
     public void onEntityCollision(Entity target) {
         // abort if it isn't on the server side and not colliding with an alive thing
-        if (CropsNHUtils.isClient() || !(target instanceof EntityLivingBase entity)) return;
+        if (!(target instanceof EntityLivingBase entity)) return;
 
         // only on living entities plz
         if (this.canTrample() && (this.shouldTrampleFromRunning(entity) || this.shouldTrampleFromFalling(entity))) {
@@ -1516,16 +1518,29 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
 
         // always prevent collision events if the entity is sneaking
         if (this.hasCrop() && !entity.isSneaking()) {
-            if (this.seed.getCrop()
-                .getEntityDamage() > 0) {
-                damageEntity(
-                    entity,
-                    this.seed.getCrop()
-                        .getEntityDamage());
+            // check if boots provide protection.
+            float damage = this.seed.getCrop()
+                .getEntityDamage();
+            if (damage > 0.0f) {
+                // something in the pack is preventing partial damage ticks, IDK what it is so just use partial hits
+                // to simulate lower damage, and effectively just reduce the likely-hood for a damage hit by what ever
+                // protection the boots give. We don't want to just do a random check here since the real thing
+                // controlling the damage flow is the small hit immunity window that players are given, so we just rely
+                // on the mini hits that don't damage the player to reduce the likely-hood of damage.
+                final float protection = this.getBootProtection(entity);
+                if (protection < BootProtectionRegistry.FULL_PROTECTION) {
+                    damageEntity(entity, XSTR.XSTR_INSTANCE.nextFloat() < protection ? 0.01f : damage);
+                }
             }
             seed.getCrop()
                 .onEntityCollision(this, target);
         }
+    }
+
+    @Override
+    public float getBootProtection(EntityLivingBase entity) {
+        final ItemStack boots = entity.getEquipmentInSlot(1);
+        return BootProtectionRegistry.instance.getProtection(boots, entity, this);
     }
 
     /**
@@ -1534,7 +1549,7 @@ public class TileEntityCropSticks extends TileEntityCropsNH implements ICropStic
      * @param entity The entity to damage.
      * @param damage The damage to apply.
      */
-    private void damageEntity(EntityLivingBase entity, float damage) {
+    protected void damageEntity(EntityLivingBase entity, float damage) {
         // don't damage immune targets
         if (entity instanceof EntityPlayer && ((EntityPlayer) entity).capabilities.disableDamage) {
             return;

--- a/src/main/java/com/gtnewhorizon/cropsnh/utility/MetaMap.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/utility/MetaMap.java
@@ -74,18 +74,17 @@ public class MetaMap<K, V> {
     /**
      * Gets the value for an item in the map
      *
-     * @implSpec returns null if not found.
+     * @apiNote returns null if not found.
      *
      * @param key  The item or block to insert.
      * @param meta The metadata of the block or item.
      * @return The value ot insert.
      */
     public V get(final K key, final int meta) {
-        if (isWildCard(meta)) {
+        // if the meta is a wildcard or it just not in the layered registry, check wildcards.
+        if (isWildCard(meta) || !this.map.containsKey(key)) {
             return this.wildcards.get(key);
         }
-        // check if the key is
-        if (!this.map.containsKey(key)) return null;
         Int2ObjectOpenHashMap<V> metaMap = this.map.get(key);
         if (metaMap.containsKey(meta)) {
             return metaMap.get(meta);
@@ -102,12 +101,8 @@ public class MetaMap<K, V> {
      * @return The value ot insert.
      */
     public V getOrDefault(final K key, final int meta, final V defaultValue) {
-        // check if the key is
-        if (isWildCard(meta)) {
-            return this.wildcards.getOrDefault(key, defaultValue);
-        }
-        // if key not found in meta map, check wildcards
-        if (!this.map.containsKey(key)) {
+        // if the meta is a wildcard or it just not in the layered registry, check wildcards.
+        if (isWildCard(meta) || !this.map.containsKey(key)) {
             return this.wildcards.getOrDefault(key, defaultValue);
         }
         // fetch the meta map

--- a/src/main/java/com/gtnewhorizon/cropsnh/utility/MetaMap.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/utility/MetaMap.java
@@ -74,6 +74,8 @@ public class MetaMap<K, V> {
     /**
      * Gets the value for an item in the map
      *
+     * @implSpec returns null if not found.
+     *
      * @param key  The item or block to insert.
      * @param meta The metadata of the block or item.
      * @return The value ot insert.

--- a/src/main/java/com/gtnewhorizon/cropsnh/utility/ModUtils.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/utility/ModUtils.java
@@ -22,6 +22,9 @@ public enum ModUtils implements IMod {
     Botania(ModIDs.Botania),
     Chisel(ModIDs.Chisel),
     CropsPlusPlus(ModIDs.CropsPlusPlus),
+    DraconicEvolution(ModIDs.DraconicEvolution),
+    ElectroMagicTools(ModIDs.ElectroMagicTools),
+    EnderIO(ModIDs.EnderIO),
     EtFuturumRequiem(ModIDs.EtFuturumRequiem),
     ExtraUtilities(ModIDs.ExtraUtilities),
     FindIt(ModIDs.FindIt),
@@ -46,6 +49,7 @@ public enum ModUtils implements IMod {
     TaintedMagic(ModIDs.TaintedMagic),
     Thaumcraft(ModIDs.Thaumcraft),
     ThaumicBases(ModIDs.ThaumicBases),
+    ThaumicBoots(ModIDs.ThaumicBoots),
     ThaumicTinkerer(ModIDs.ThaumicTinkerer),
     TinkerConstruct(ModIDs.TinkerConstruct),
     TwilightForest(ModIDs.TwilightForest),
@@ -153,6 +157,9 @@ public enum ModUtils implements IMod {
         public static final String Botania = "Botania";
         public static final String Chisel = "chisel";
         public static final String CropsPlusPlus = "berriespp";
+        public static final String DraconicEvolution = "DraconicEvolution";
+        public static final String ElectroMagicTools = "EMT";
+        public static final String EnderIO = "EnderIO";
         public static final String EtFuturumRequiem = "etfuturum";
         public static final String ExtraUtilities = "ExtraUtilities";
         public static final String FindIt = "findit";
@@ -177,6 +184,7 @@ public enum ModUtils implements IMod {
         public static final String TaintedMagic = "TaintedMagic";
         public static final String Thaumcraft = "Thaumcraft";
         public static final String ThaumicBases = "thaumicbases";
+        public static final String ThaumicBoots = "thaumicboots";
         public static final String ThaumicTinkerer = "ThaumicTinkerer";
         public static final String TinkerConstruct = "TConstruct";
         public static final String TwilightForest = "TwilightForest";

--- a/src/main/resources/assets/cropsnh/lang/en_US.lang
+++ b/src/main/resources/assets/cropsnh/lang/en_US.lang
@@ -547,6 +547,7 @@ nei.options.tools.dump.cropsnh.hydrationFluids=Hydration
 nei.options.tools.dump.cropsnh.mutationPools=Mutation Pools
 nei.options.tools.dump.cropsnh.soilRegistry=Soils
 nei.options.tools.dump.cropsnh.weedEXFluids=WeedEX
+nei.options.tools.dump.cropsnh.bootProtection=Boot Protection
 
 
 # Generic Seeds


### PR DESCRIPTION
## Summary
This is a feature from crops++ I wasn't aware of. Apparently, I could have sworn I've been walking in my crop fields with quantum or nanot boot and taken damage from them, but I guess I remembered wrong or i've always used the EMT/thaumic boot varients: https://github.com/GTNH-Museum/Crops-plus-plus/blob/dbf3e87eaf1312cf07a53c62e018d27cfb805a51/src/main/java/com/github/bartimaeusnek/cropspp/CCropUtility.java#L88

This system comes with some improvements over the crops++ implementation:
- A new registry has been added to store and lookup protection handlers.
- Protection handlers are given the boot item, the entity and the crop tick being collided with, and must return a value indicating how much protection the given item gives. The value is a floating point ranging from 0 to 1, with 0 providing no protection and 1 providing full immunity.
  - Handlers are made to be customizable so we can have more complex damage mechanisms down the line.
- A much wider set of boots now grant either partial or full protection against collision effects.
  - Leather boots reduce the damage by 75% if IC2/rubber boots exist.
  - Rubber boots and other boots that are not powered but provide hazmat protections are given full immunity, but they will take damage as the player moves around at a 1% chance every tick.
  - Any boot that provides hazmat protections and is powered or that provides spacesuit protections gives full immunity without taking any damage.
  - A new nei dump tool has been added to view the list of registered boots at runtime.


The current dump of the registry from a full pack instance (daily 645):
[bootProtection.csv](https://github.com/user-attachments/files/30436928/bootProtection.csv)

Leather boots, item takes damage, 75% damage/effect reduction to player:
<img width="199" height="85" alt="image" src="https://github.com/user-attachments/assets/9f145c4a-7c79-49e5-be9e-65b21dd92023" />

Basic hazmat boots, item takes damage, full immunity:
<img width="180" height="64" alt="image" src="https://github.com/user-attachments/assets/85841a7b-f389-4729-8486-71eea740d09e" />
(The second rubber pair is some adv rubber boots from gt++)

Full hazmat boots, item does not take damage, full immunity:
<img width="511" height="188" alt="image" src="https://github.com/user-attachments/assets/ba759129-21f8-495c-b168-d95707566784" />

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
  - Daily 645 (client and server) 
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
