### PR TITLE
Fix recipe conflict and titanium to desh conversion

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,81 +2,82 @@
 
 dependencies {
     // compile and runtime required dependencies
-    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.54.46:dev")
-    api("com.github.GTNewHorizons:GTNHLib:0.11.30:dev")
+    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.54.75:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.11.36:dev")
     shadowImplementation('com.github.makamys:MCLib:0.3.7.8') {
         exclude group: "codechicken"
     }
 
     // compile required dependencies
     devOnlyNonPublishable("com.github.GTNewHorizons:TinkersConstruct:1.14.96-GTNH:dev") { transitive = false }
-    devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.114-GTNH:dev") { transitive = false }
+    devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.118-GTNH:dev") { transitive = false }
     devOnlyNonPublishable("com.github.GTNewHorizons:waila:1.19.31:dev") { transitive = false }
-    devOnlyNonPublishable("com.github.GTNewHorizons:ForestryMC:4.11.31:dev") { transitive = false }
+    devOnlyNonPublishable("com.github.GTNewHorizons:ForestryMC:4.11.32:dev") { transitive = false }
     devOnlyNonPublishable("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
-    devOnlyNonPublishable('com.github.GTNewHorizons:Backhand:1.8.12:dev') { transitive = false }
-    devOnlyNonPublishable('com.github.GTNewHorizons:FindIt:1.4.3:dev') { transitive = false }
+    devOnlyNonPublishable('com.github.GTNewHorizons:Backhand:1.8.13:dev') { transitive = false }
+    devOnlyNonPublishable('com.github.GTNewHorizons:FindIt:1.4.4:dev') { transitive = false }
 
     // // optional runtime dependencies, you'll want to copy over the full pack configs to your dev env or else it will crash.
     // // debugging tools
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:NewHorizonsCoreMod:2.9.20:dev")
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:ServerUtilities:2.4.3:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:NewHorizonsCoreMod:2.9.29:dev")
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:ServerUtilities:2.4.6:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:worldedit-gtnh:v0.0.9:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:WAILAPlugins:0.7.2:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:EnderCore:0.5.14:dev") { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.114-GTNH:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.118-GTNH:dev") { transitive = false }
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:Opis:1.4.9-mapless:dev') { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:GTNHLib:0.11.30:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:GTNHLib:0.11.36:dev") { transitive = false }
     // // QOL/creature comforts
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-999-GTNH:dev") { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.5.97-gtnh:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.5.100-gtnh:dev") { transitive = false }
     // var tasks = project.gradle.startParameter.taskNames
     // if (tasks.contains("runClient17") || tasks.contains("runClient21") || tasks.contains("runClient25")) {
-    //     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Angelica:2.1.54:dev") { transitive = false }
+    //     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Angelica:2.1.60:dev") { transitive = false }
     // }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Hodgepodge:2.7.174:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Hodgepodge:2.7.180:dev") { transitive = false }
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:CoreTweaks:0.3.4.7-GTNH:dev') { transitive = false }
-    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:StorageDrawers:2.2.26-GTNH:dev') { transitive = false }
+    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:StorageDrawers:2.2.28-GTNH:dev') { transitive = false }
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:MouseTweaks:2.5.2-GTNH:dev') { transitive = false }
     // // rendering IF structure in NEI
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:StructureLib:1.4.42:dev") { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:BlockRenderer6343:1.4.17:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:BlockRenderer6343:1.4.21:dev") { transitive = false }
     // // to check what counts as food
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:AppleCore:3.3.11:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:SpiceOfLife:2.2.10-carrot:dev") { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Nutrition:0.1.10:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Nutrition:1.0.1:dev") { transitive = false }
     // // bee comparisons
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:BeeBetterAtBees-GTNH:0.4.7-GTNH:dev") { transitive = false }
-    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:Binnie:2.6.36:dev') { transitive = false }
+    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:Binnie:2.6.39:dev') { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:neiaddons:1.18.4:dev") { transitive = false }
     // // for mod specific crops
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Natura:2.8.20:dev") { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:twilightforest:2.7.36:dev") { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:ThaumicBases:1.9.18:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Natura:2.8.23:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:twilightforest:2.7.38:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:ThaumicBases:1.9.19:dev") { transitive = false }
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:DummyCore:1.21.0:dev') { transitive = false }
     // runtimeOnlyNonPublishable("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
     // runtimeOnlyNonPublishable(deobfCurse('witchery-69673:2234410')) { transitive = false }
     // runtimeOnlyNonPublishable(rfg.deobf("curse.maven:biomes-o-plenty-220318:2499612")) { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Botania:1.13.27-GTNH:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Botania:1.13.32-GTNH:dev") { transitive = false }
     // runtimeOnlyNonPublishable("ganymedes01.etfuturum:Et-Futurum-Requiem:2.6.12-GTNH") { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:harvestcraft:1.3.11-GTNH:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:harvestcraft:1.3.13-GTNH:dev") { transitive = false }
     // // testing recipes
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Tainted-Magic:7.7.8-GTNH:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:WitcheryExtras:1.4.16:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:WitchingGadgets:1.8.48-GTNH:dev") { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:ThaumicTinkerer:2.12.27:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:ThaumicTinkerer:2.12.29:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Galaxy-Space-GTNH:1.1.139-GTNH:dev") { transitive = false }
     // // required in order to have pam
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Chisel:2.17.30-GTNH:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Chisel:2.17.31-GTNH:dev") { transitive = false }
     // // mod specific crops and soils
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Galacticraft:3.4.31-GTNH:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Galacticraft:3.4.32-GTNH:dev") { transitive = false }
     // // soil debugging
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Random-Things:2.7.8:dev") { transitive = false }
     // runtimeOnlyNonPublishable(rfg.deobf("curse.maven:ztones-224369:2223720")) { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:MagicBees:2.10.9-GTNH:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:MagicBees:2.10.10-GTNH:dev") { transitive = false }
     // // required in order for ztones to load right due to GT5u
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:BuildCraft:7.1.61:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:BuildCraft:7.1.63:dev") { transitive = false }
     // // skull underblock requirement
-    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:EnderIO:2.10.34:dev') { transitive = false }
+    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:EnderIO:2.10.36:dev') { transitive = false }
     // // watering can interactions
     // runtimeOnlyNonPublishable(rfg.deobf("curse.maven:extra-utilities-225561:2264383")) { transitive = false }
 }

--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropRecipes.java
@@ -58,6 +58,7 @@ import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
 import gregtech.api.interfaces.IRecipeMap;
+import gregtech.api.objects.OreDictItemStack;
 import gregtech.api.recipe.RecipeMaps;
 import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTOreDictUnificator;
@@ -1001,45 +1002,45 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
         if (!ModUtils.GalacticraftCore.isModLoaded()) return;
         // space flower to uum
         recipe(4, 6, 40).itemInputs(MaterialLeafLoader.spaceFlower.get(1))
-            // it's growth time should make it worst than using uum berries
+            // it's growth time should make it worse than using uum berries
             .fluidOutputs(Materials.UUMatter.getFluid(4))
             .addTo(fluidExtractionRecipes);
 
         // iron to meteoric iron
-        hvRecipe(12, 0).itemInputs(new Object[] { "dustIron", 4 }, MaterialLeafLoader.spaceFlower.get(1))
-            .fluidInputs(TierAcid.t2.get())
+        hvRecipe(12, 0).itemInputs(new OreDictItemStack("dustIron", 4), MaterialLeafLoader.spaceFlower.get(1))
+            .fluidInputs(TierAcid.t3.get())
             .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.MeteoricIron, 4))
             .addTo(UniversalChemical);
 
         // steel to meteoric steel
-        hvRecipe(12, 0).itemInputs(new Object[] { "dustSteel", 4 }, MaterialLeafLoader.spaceFlower.get(1))
-            .fluidInputs(TierAcid.t2.get())
-            .itemOutputs(Materials.MeteoricSteel.getDust(4))
+        hvRecipe(12, 0).itemInputs(new OreDictItemStack("dustSteel", 4), MaterialLeafLoader.spaceFlower.get(1))
+            .fluidInputs(TierAcid.t3.get())
+            .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.MeteoricSteel, 4))
             .addTo(UniversalChemical);
 
         if (ModUtils.GalacticraftMars.isModLoaded()) {
             // titanium to desh
-            hvRecipe(12, 0).itemInputs(new Object[] { "dustTitanium", 4 }, MaterialLeafLoader.spaceFlower.get(4))
+            hvRecipe(12, 0).itemInputs(new OreDictItemStack("dustTitanium", 4), MaterialLeafLoader.spaceFlower.get(4))
                 .fluidInputs(TierAcid.t4.get())
-                .itemOutputs(Materials.Oriharukon.getDust(4))
+                .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Desh, 4))
                 .addTo(UniversalChemical);
         }
 
         if (ModUtils.GalaxySpace.isModLoaded()) {
             // bismuth to oriharukon
-            hvRecipe(12, 0).itemInputs(new Object[] { "dustBismuth", 4 }, MaterialLeafLoader.spaceFlower.get(8))
+            hvRecipe(12, 0).itemInputs(new OreDictItemStack("dustBismuth", 4), MaterialLeafLoader.spaceFlower.get(8))
                 .fluidInputs(TierAcid.t4.get())
-                .itemOutputs(Materials.Oriharukon.getDust(4))
+                .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Oriharukon, 4))
                 .addTo(UniversalChemical);
 
             // ice to callistoIce
-            ivRecipe(12, 0).itemInputs(new Object[] { "dustIce", 4 }, MaterialLeafLoader.spaceFlower.get(8))
+            ivRecipe(12, 0).itemInputs(new OreDictItemStack("dustIce", 4), MaterialLeafLoader.spaceFlower.get(8))
                 .fluidInputs(TierAcid.t5.get())
                 .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.CallistoIce, 4))
                 .addTo(UniversalChemical);
 
             // lead to ledox
-            ivRecipe(12, 0).itemInputs(new Object[] { "dustLead", 4 }, MaterialLeafLoader.spaceFlower.get(8))
+            ivRecipe(12, 0).itemInputs(new OreDictItemStack("dustLead", 4), MaterialLeafLoader.spaceFlower.get(8))
                 .fluidInputs(TierAcid.t5.get())
                 .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Ledox, 4))
                 .addTo(UniversalChemical);
@@ -1056,13 +1057,15 @@ public abstract class CropRecipes extends BaseGTRecipeLoader {
             }
 
             // meteoric iron to deep iron
-            zpmRecipe(6, 0).itemInputs(new Object[] { "dustMeteoricIron", 4 }, MaterialLeafLoader.spaceFlower.get(16))
+            zpmRecipe(6, 0)
+                .itemInputs(new OreDictItemStack("dustMeteoricIron", 4), MaterialLeafLoader.spaceFlower.get(16))
                 .fluidInputs(TierAcid.t6.get())
                 .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.DeepIron, 4))
                 .addTo(UniversalChemical);
 
             // pu241 to black plutonium
-            zpmRecipe(6, 0).itemInputs(new Object[] { "dustPlutonium241", 4 }, MaterialLeafLoader.spaceFlower.get(64))
+            zpmRecipe(6, 0)
+                .itemInputs(new OreDictItemStack("dustPlutonium241", 4), MaterialLeafLoader.spaceFlower.get(64))
                 .fluidInputs(TierAcid.t6.get())
                 .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.BlackPlutonium, 4))
                 .addTo(UniversalChemical);


### PR DESCRIPTION
## Summary
This PR fixes a recipe conflict with iron III chloride and the space flower meteoric iron recipe. I've opted to leave the iron III chloride as is and simply change the acid in crops NH since formic really doesn't have many other crop uses, it's fairly cheap to make, and if people are using this recipe to skip some moon exploration, it at least preps them for future plat line investments. The meteoric steel dust recipe was updated at the same time to use formic acid, keeping things consistent.

This PR also fixes an issue with the titanium-to-desh conversion recipe. It was making oriharukon for some reason, which was not intended.

It also does a bit of cleanup in the rest of the space flower recipes to better utilize the ore dict unificator in prep for future material unification.

I've also added galaxy-space to the optional commented-out runtime deps, since it should have been there to let me check the galaxy-space recipes in a dev env. I also updated all the other deps for good measure while I was at it.

## Screenshots:

New meteoric iron dust conversion recipe
<img width="514" height="344" alt="image" src="https://github.com/user-attachments/assets/cdbe142b-d27f-44e8-b3f4-8df1e42273a9" />

New meteoric steel dust conversion recipe
<img width="502" height="342" alt="image" src="https://github.com/user-attachments/assets/306288d9-bd2f-4352-8589-04c42122c80f" />

Fixed titanium to desh conversion recipe:
<img width="506" height="420" alt="image" src="https://github.com/user-attachments/assets/2f68d9ac-d77d-4370-8b36-efdd4173ad03" />

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
    - No AI used
- ❌ This PR requires another PR in order to merge
