### PR TITLE
Fix alternate seeds check in getSeedData and thus allowing them in Industrial Farms

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/utility/CropsNHUtils.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/utility/CropsNHUtils.java
@@ -28,7 +28,6 @@ import com.gtnewhorizon.cropsnh.farming.SeedData;
 import com.gtnewhorizon.cropsnh.farming.SeedStats;
 import com.gtnewhorizon.cropsnh.farming.registries.CropRegistry;
 import com.gtnewhorizon.cropsnh.handler.ConfigurationHandler;
-import com.gtnewhorizon.cropsnh.items.ItemGenericSeed;
 
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.registry.GameRegistry;
@@ -122,13 +121,13 @@ public abstract class CropsNHUtils {
      * @return Null if nothing was found else the seed data for the stack.
      */
     public static @Nullable ISeedData getSeedData(ItemStack stack, boolean allowAltSeeds, boolean analyzedOnly) {
-        if (CropsNHUtils.isStackInvalid(stack) || !(stack.getItem() instanceof ItemGenericSeed)) return null;
+        if (CropsNHUtils.isStackInvalid(stack)) return null;
         // check that it's a crop card and that it can cross.
         ICropCard cc = CropRegistry.instance.get(stack, allowAltSeeds);
         if (cc == null) return null;
         // fail if the crop isn't analyzed
         SeedStats stats = SeedStats.getStatsFromStack(stack);
-        if (stats == null || (analyzedOnly && !stats.isAnalyzed())) return null;
+        if (stats == null || (!allowAltSeeds && analyzedOnly && !stats.isAnalyzed())) return null;
         return new SeedData(cc, stats, stack);
     }
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->

Stop checking seed as instance of `ItemGenericSeed` in `CropsNHUtils.getSeedData`.

`getAnalyzedSeedData` and `getSeedData` are refactored in 8c9c295 from old `getAnalyzedSeedData`. According to the comment "analyzed seeds _or_ an alternative seed", an alternative seed should be treated as a scanned one with 1/1/1 stats, white the existing implementation would return because of `!(stack.getItem() instanceof ItemGenericSeed)`.

Also, in `readFromNBT` method, an alt seed without `Names.NBT.analyzed` tag would be treated as not scanned. Thus we need a bypass here if `allowAltSeeds` is true. Or maybe we should place this logic into `readFromNBT`?

This PR enables alternate seeds to be input into Industrial Farms as-is.

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
