### PR TITLE
Make getAnalyzedSeedData calls more verbose

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/compatibility/NEI/CropsNHNEICropGeneExtractorHandler.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/compatibility/NEI/CropsNHNEICropGeneExtractorHandler.java
@@ -35,7 +35,7 @@ public class CropsNHNEICropGeneExtractorHandler extends GTNEIDefaultHandler {
     }
 
     private void findValidRecipe(ItemStack stack, Consumer<ItemStack> superCall) {
-        ISeedData seedData = CropsNHUtils.getAnalyzedSeedData(stack);
+        ISeedData seedData = CropsNHUtils.getSeedData(stack, false, true);
         if (seedData == null) {
             superCall.accept(stack);
             return;

--- a/src/main/java/com/gtnewhorizon/cropsnh/compatibility/NEI/CropsNHNEICropSynthesizerHandler.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/compatibility/NEI/CropsNHNEICropSynthesizerHandler.java
@@ -50,7 +50,7 @@ public class CropsNHNEICropSynthesizerHandler extends GTNEIDefaultHandler {
     }
 
     private void findValidRecipe(ItemStack stack, Consumer<ItemStack> superCall) {
-        ISeedData seedData = CropsNHUtils.getAnalyzedSeedData(stack);
+        ISeedData seedData = CropsNHUtils.getSeedData(stack, false, true);
         if (seedData == null) {
             superCall.accept(stack);
             return;

--- a/src/main/java/com/gtnewhorizon/cropsnh/compatibility/NEI/CropsNHNEISeedGeneratorHandler.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/compatibility/NEI/CropsNHNEISeedGeneratorHandler.java
@@ -35,7 +35,7 @@ public class CropsNHNEISeedGeneratorHandler extends GTNEIDefaultHandler {
     }
 
     private void findValidRecipe(ItemStack stack, Consumer<ItemStack> superCall) {
-        ISeedData seedData = CropsNHUtils.getAnalyzedSeedData(stack);
+        ISeedData seedData = CropsNHUtils.getSeedData(stack, false, true);
         if (seedData == null) {
             superCall.accept(stack);
             return;

--- a/src/main/java/com/gtnewhorizon/cropsnh/compatibility/NEI/NEICropsNHAlternateSeedHandler.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/compatibility/NEI/NEICropsNHAlternateSeedHandler.java
@@ -91,7 +91,7 @@ public class NEICropsNHAlternateSeedHandler extends CropsNHNEIHandler {
 
     @Override
     protected void loadCraftingRecipesDo(ItemStack stack) {
-        ISeedData seedData = CropsNHUtils.getAnalyzedSeedData(stack);
+        ISeedData seedData = CropsNHUtils.getSeedData(stack, false, true);
         if (seedData == null || isBadArg(stack)) {
             return;
         }

--- a/src/main/java/com/gtnewhorizon/cropsnh/items/ItemGenericSeed.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/items/ItemGenericSeed.java
@@ -105,7 +105,7 @@ public class ItemGenericSeed extends ItemCropsNH {
     @Override
     public EnumRarity getRarity(ItemStack stack) {
         // load the crop card
-        ISeedData seedData = CropsNHUtils.getAnalyzedSeedData(stack);
+        ISeedData seedData = CropsNHUtils.getSeedData(stack, false, true);
         if (seedData == null) return super.getRarity(stack);
 
         return seedData.getCrop()

--- a/src/main/java/com/gtnewhorizon/cropsnh/recipes/backends/CropBreederBackend.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/recipes/backends/CropBreederBackend.java
@@ -44,7 +44,7 @@ public class CropBreederBackend extends RecipeMapBackend {
 
     @Override
     public boolean containsInput(ItemStack item) {
-        ISeedData seedData = CropsNHUtils.getAnalyzedSeedData(item);
+        ISeedData seedData = CropsNHUtils.getSeedData(item, false, true);
         return seedData != null ? cropIndex.containsKey(seedData.getCrop()) : super.containsInput(item);
     }
 }

--- a/src/main/java/com/gtnewhorizon/cropsnh/recipes/backends/CropGeneExtractorBackend.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/recipes/backends/CropGeneExtractorBackend.java
@@ -34,7 +34,7 @@ public class CropGeneExtractorBackend extends RecipeMapBackend {
 
     @Override
     public boolean containsInput(ItemStack item) {
-        ISeedData seedData = CropsNHUtils.getAnalyzedSeedData(item);
+        ISeedData seedData = CropsNHUtils.getSeedData(item, false, true);
         return (seedData != null && cropIndex.containsKey(seedData.getCrop())) || super.containsInput(item);
     }
 }

--- a/src/main/java/com/gtnewhorizon/cropsnh/recipes/backends/CropSynthesizerBackend.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/recipes/backends/CropSynthesizerBackend.java
@@ -37,7 +37,7 @@ public class CropSynthesizerBackend extends RecipeMapBackend {
 
     @Override
     public boolean containsInput(ItemStack item) {
-        ISeedData seedData = CropsNHUtils.getAnalyzedSeedData(item);
+        ISeedData seedData = CropsNHUtils.getSeedData(item, false, true);
         return (seedData != null && cropIndex.containsKey(seedData.getCrop())) || super.containsInput(item);
     }
 }

--- a/src/main/java/com/gtnewhorizon/cropsnh/recipes/backends/SeedGeneratorBackend.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/recipes/backends/SeedGeneratorBackend.java
@@ -34,7 +34,7 @@ public class SeedGeneratorBackend extends RecipeMapBackend {
 
     @Override
     public boolean containsInput(ItemStack item) {
-        ISeedData seedData = CropsNHUtils.getAnalyzedSeedData(item);
+        ISeedData seedData = CropsNHUtils.getSeedData(item, false, true);
         return (seedData != null && cropIndex.containsKey(seedData.getCrop())) || super.containsInput(item);
     }
 }

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
@@ -764,7 +764,7 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
                 formatNumber(this.getFertilizerPotencyNeededPerCycle()) + getFluidUnit(),
                 formatNumber(CYCLE_DURATION)));
         // nutrient score
-        ISeedData seedData = CropsNHUtils.getAnalyzedSeedData(this.getSeedStack());
+        ISeedData seedData = CropsNHUtils.getSeedData(this.getSeedStack(), false, true);
         if (seedData != null) {
             ret.add(
                 StatCollector.translateToLocalFormatted(
@@ -984,7 +984,7 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
             // the seed must be a valid item and an analyzed seed.
             final ItemStack seedCandidate = inputs.get(seedIndex);
             // check if it's an analyzed crop
-            final ISeedData seedData = CropsNHUtils.getAnalyzedSeedData(seedCandidate);
+            final ISeedData seedData = CropsNHUtils.getSeedData(seedCandidate, false, true);
             if (seedData == null) continue;
             if (seedData.getCrop()
                 .getMinSeedBedTier() > this.upgradeTier) return CHECK_RECIPE_RESULT_SEED_BED_TIER_TOO_LOW;
@@ -1203,7 +1203,7 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
         if (this.upgradeTier < MIN_CASING_TIER) return CheckRecipeResultRegistry.INTERNAL_ERROR;
 
         // get seed
-        ISeedData seedData = CropsNHUtils.getAnalyzedSeedData(this.getSeedStack());
+        ISeedData seedData = CropsNHUtils.getSeedData(this.getSeedStack(), false, true);
         if (seedData == null) return CheckRecipeResultRegistry.NO_RECIPE;
 
         // check if the seed can grow in the machine.

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarmItemStackHandler.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarmItemStackHandler.java
@@ -37,7 +37,7 @@ public class MTEIndustrialFarmItemStackHandler extends ItemStackHandler {
 
         switch (slot) {
             case MTEIndustrialFarm.SLOT_SEED -> {
-                ISeedData seedData = CropsNHUtils.getAnalyzedSeedData(stack);
+                ISeedData seedData = CropsNHUtils.getSeedData(stack, false, true);
                 if (seedData == null) return false;
                 if (seedData.getCrop()
                     .getMinSeedBedTier() > this.multiblock.upgradeTier) return false;

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/singleblock/MTECropGeneExtractor.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/singleblock/MTECropGeneExtractor.java
@@ -139,7 +139,7 @@ public class MTECropGeneExtractor extends MTEBasicMachine {
 
     @Override
     public int checkRecipe(boolean skipOC) {
-        ISeedData seedData = CropsNHUtils.getAnalyzedSeedData(getInputAt(0));
+        ISeedData seedData = CropsNHUtils.getSeedData(getInputAt(0), false, true);
         ItemStack circuitStack = getStackInSlot(getCircuitSlot());
         ItemStack dataOrb = getSpecialSlot();
 
@@ -245,7 +245,7 @@ public class MTECropGeneExtractor extends MTEBasicMachine {
             return isDataOrb(stack);
         }
         if (index == this.getInputSlot()) {
-            return CropsNHUtils.getAnalyzedSeedData(stack) != null;
+            return CropsNHUtils.getSeedData(stack, false, true) != null;
         }
         return super.allowPutStackValidated(baseMetaTileEntity, index, side, stack);
     }

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/singleblock/MTESeedGenerator.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/singleblock/MTESeedGenerator.java
@@ -183,7 +183,7 @@ public class MTESeedGenerator extends MTEBasicMachine {
         int fluidToConsume = 0;
         outer: for (int i = 0; i < this.mInputSlotCount; i++) {
             ItemStack stackInSlot = this.getInputAt(i);
-            seedData = CropsNHUtils.getAnalyzedSeedData(stackInSlot);
+            seedData = CropsNHUtils.getSeedData(stackInSlot, false, true);
             if (seedData != null) {
                 // don't replicate seeds that require the synthesizer in the seed generator
                 if (seedData.getCrop()

--- a/src/main/java/com/gtnewhorizon/cropsnh/utility/CropsNHUtils.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/utility/CropsNHUtils.java
@@ -96,7 +96,7 @@ public abstract class CropsNHUtils {
     /**
      * Attempts to get the seed data for a given stack.
      *
-     * @apiNote Alt seeds are treated as analyzed seeds with default stats when found.
+     * @apiNote Alt seeds are treated as analyzed seeds with default analyzed stats when allowed and found.
      *
      * @param stack         The stack to validate
      * @param allowAltSeeds True to allow alt seeds to be parsed.

--- a/src/main/java/com/gtnewhorizon/cropsnh/utility/CropsNHUtils.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/utility/CropsNHUtils.java
@@ -104,7 +104,7 @@ public abstract class CropsNHUtils {
      * @return Null if nothing was found else the seed data for the stack.
      */
     public static @Nullable ISeedData getSeedData(ItemStack stack, boolean allowAltSeeds, boolean analyzedOnly) {
-        final boolean isAltSeed = stack.getItem() instanceof ItemGenericSeed;
+        final boolean isAltSeed = !(stack.getItem() instanceof ItemGenericSeed);
         if (CropsNHUtils.isStackInvalid(stack) || (isAltSeed && !allowAltSeeds)) return null;
         // check that it's a crop card and that it can cross.
         ICropCard cc = CropRegistry.instance.get(stack, allowAltSeeds);

--- a/src/main/java/com/gtnewhorizon/cropsnh/utility/CropsNHUtils.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/utility/CropsNHUtils.java
@@ -94,39 +94,24 @@ public abstract class CropsNHUtils {
     }
 
     /**
-     * Attempts to detect if the stack contains analyzed seeds, or an alternative seed.
-     *
-     * @param stack The stack to validate
-     * @return Null if nothing was found else the seed data for the stack.
-     */
-    public static @Nullable ISeedData getAnalyzedSeedData(ItemStack stack) {
-        return getSeedData(stack, true, true);
-    }
-
-    /**
      * Attempts to detect if the stack contains analyzed seeds or an alternative seed if allowed.
      *
      * @param stack         The stack to validate
      * @param allowAltSeeds True to allow alt seeds to be parsed.
-     * @return Null if nothing was found else the seed data for the stack.
-     */
-    public static @Nullable ISeedData getAnalyzedSeedData(ItemStack stack, boolean allowAltSeeds) {
-        return getSeedData(stack, allowAltSeeds, true);
-    }
-
-    /**
-     * Attempts to detect if the stack contains analyzed seeds or an alternative seed if allowed.
-     *
-     * @param stack         The stack to validate
-     * @param allowAltSeeds True to allow alt seeds to be parsed.
+     * @param analyzedOnly  True to block unanalyzed seeds from being parsed.
      * @return Null if nothing was found else the seed data for the stack.
      */
     public static @Nullable ISeedData getSeedData(ItemStack stack, boolean allowAltSeeds, boolean analyzedOnly) {
-        if (CropsNHUtils.isStackInvalid(stack) || !(stack.getItem() instanceof ItemGenericSeed)) return null;
+        final boolean isAltSeed = stack.getItem() instanceof ItemGenericSeed;
+        if (CropsNHUtils.isStackInvalid(stack) || (isAltSeed && !allowAltSeeds)) return null;
         // check that it's a crop card and that it can cross.
         ICropCard cc = CropRegistry.instance.get(stack, allowAltSeeds);
         if (cc == null) return null;
         // fail if the crop isn't analyzed
+        if (isAltSeed) {
+            // if it's an alt seed no need to check for stats
+            return new SeedData(cc, SeedStats.DEFAULT_ANALYZED, stack);
+        }
         SeedStats stats = SeedStats.getStatsFromStack(stack);
         if (stats == null || (analyzedOnly && !stats.isAnalyzed())) return null;
         return new SeedData(cc, stats, stack);

--- a/src/main/java/com/gtnewhorizon/cropsnh/utility/CropsNHUtils.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/utility/CropsNHUtils.java
@@ -96,6 +96,8 @@ public abstract class CropsNHUtils {
     /**
      * Attempts to get the seed data for a given stack.
      *
+     * @apiNote Alt seeds are treated as analyzed seeds with default stats when found.
+     *
      * @param stack         The stack to validate
      * @param allowAltSeeds True to allow alt seeds to be parsed.
      * @param analyzedOnly  True to block unanalyzed seeds from being parsed.

--- a/src/main/java/com/gtnewhorizon/cropsnh/utility/CropsNHUtils.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/utility/CropsNHUtils.java
@@ -94,7 +94,7 @@ public abstract class CropsNHUtils {
     }
 
     /**
-     * Attempts to detect if the stack contains analyzed seeds or an alternative seed if allowed.
+     * Attempts to get the seed data for a given stack.
      *
      * @param stack         The stack to validate
      * @param allowAltSeeds True to allow alt seeds to be parsed.


### PR DESCRIPTION
## Summary
This PR doesn't change anything functionality-wise, but it does resolve a future bug where alt seeds couldn't be resolved correctly by get seed data. The code does say it should allow them, but nothing that ever called this `getSeedData` has ever allowed alt seeds, so it worked out.

It verbosifies all the `getAnalyzedSeedData` calls, since I prefer them to be more explicit at the call site rather than relying on function overloads in order to better describe the exact intent. This PR should help prevent misunderstandings like the one that sparked #235, in which the documentation incorrectly implied that the single-parameter function accepted alt seeds.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
  - No AI used 
- ❌  This PR requires another PR in order to merge
