### PR TITLE
Fix getSeedData NPE (For 2.9)

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/utility/CropsNHUtils.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/utility/CropsNHUtils.java
@@ -103,18 +103,24 @@ public abstract class CropsNHUtils {
      * @param analyzedOnly  True to block unanalyzed seeds from being parsed.
      * @return Null if nothing was found else the seed data for the stack.
      */
-    public static @Nullable ISeedData getSeedData(ItemStack stack, boolean allowAltSeeds, boolean analyzedOnly) {
+    @Contract("null,_,_->null")
+    public static @Nullable ISeedData getSeedData(@Nullable ItemStack stack, boolean allowAltSeeds,
+        boolean analyzedOnly) {
+        // null check the params
+        if (CropsNHUtils.isStackInvalid(stack)) return null;
+        // All crop seed items should either be instances of ItemGenericSeed or inherit from it.
         final boolean isAltSeed = !(stack.getItem() instanceof ItemGenericSeed);
-        if (CropsNHUtils.isStackInvalid(stack) || (isAltSeed && !allowAltSeeds)) return null;
-        // check that it's a crop card and that it can cross.
-        ICropCard cc = CropRegistry.instance.get(stack, allowAltSeeds);
+        if (isAltSeed && !allowAltSeeds) return null;
+        // Check if the stack has an associated crop card
+        final ICropCard cc = CropRegistry.instance.get(stack, allowAltSeeds);
         if (cc == null) return null;
-        // fail if the crop isn't analyzed
+        // if we found an alt seeds return it as a default-stat analyzed seed.
         if (isAltSeed) {
-            // if it's an alt seed no need to check for stats
             return new SeedData(cc, SeedStats.DEFAULT_ANALYZED, stack);
         }
-        SeedStats stats = SeedStats.getStatsFromStack(stack);
+        // fail if the crop doesn't have stats (no alt seeds should reach this) or if the crop isn't analyzed and we're
+        // only allowing analyzed seeds
+        final SeedStats stats = SeedStats.getStatsFromStack(stack);
         if (stats == null || (analyzedOnly && !stats.isAnalyzed())) return null;
         return new SeedData(cc, stats, stack);
     }


### PR DESCRIPTION
## Summary
Fixes an NPE in the recently updated `getSeedData` function.

Resolves #240

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
  - No AI used 
- ❌ This PR requires another PR in order to merge
