### PR TITLE
Fix energy slot not doing the energy slot work because it was not an energy slot 

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/singleblock/MTECropManager.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/singleblock/MTECropManager.java
@@ -681,7 +681,7 @@ public class MTECropManager extends MTETieredMachineBlock {
 
     @Override
     public boolean isItemValidForSlot(int index, ItemStack stack) {
-        return allowPutStack(index, stack);
+        return index == SLOT_BATTERY || allowPutStack(index, stack);
     }
 
     public static boolean isFertilizerStack(ItemStack stack) {


### PR DESCRIPTION
## Summary
redstone in energy slot not worky worky

now it do worky worky

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
