### PR TITLE
Remove useless recipe removals

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/GTRecipeLoader.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/GTRecipeLoader.java
@@ -84,7 +84,7 @@ public abstract class GTRecipeLoader extends BaseGTRecipeLoader {
 
         GTModHandler.addCraftingRecipe(
             CropsNHItemList.plantLens.get(1),
-            GTModHandler.RecipeBits.BITSD,
+            GTModHandler.RecipeBits.BITSD | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
             new Object[] { " fL", " Sr", "S  ", 'L', OrePrefixes.lens.get(Materials.Glass), 'S', "stickWood" });
     }
 
@@ -92,7 +92,7 @@ public abstract class GTRecipeLoader extends BaseGTRecipeLoader {
         // steel locked
         GTModHandler.addCraftingRecipe(
             CropsNHItemList.spade.get(1),
-            GTModHandler.RecipeBits.BITSD,
+            GTModHandler.RecipeBits.BITSD | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
             new Object[] {
                 // spotless:off
                 "fPh",
@@ -106,7 +106,7 @@ public abstract class GTRecipeLoader extends BaseGTRecipeLoader {
         // mv-bender locked
         GTModHandler.addCraftingRecipe(
             CropsNHItemList.reinforcedSpade.get(1),
-            GTModHandler.RecipeBits.BITSD,
+            GTModHandler.RecipeBits.BITSD | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
             new Object[] {
                 // spotless:off
                 "fPh",
@@ -130,7 +130,8 @@ public abstract class GTRecipeLoader extends BaseGTRecipeLoader {
     private static void addMugRecipe() {
         GTModHandler.addCraftingRecipe(
             CropsNHItemList.emptyMug.get(1),
-            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED
+                | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
             new Object[] { "PhP", " P ", 'P', "plateStone" });
     }
 
@@ -161,7 +162,7 @@ public abstract class GTRecipeLoader extends BaseGTRecipeLoader {
 
         GTModHandler.addCraftingRecipe(
             CropsNHItemList.cropSticks.get(ConfigurationHandler.cropsPerCraft),
-            GTModHandler.RecipeBits.BITS,
+            GTModHandler.RecipeBits.BITS | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
             new Object[] { "S S", "S S", 'S', "stickLongWood" });
 
         ulvRecipe(2, 0)

--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropsPlusPlusRecipes.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/gtrecipes/CropsPlusPlusRecipes.java
@@ -55,7 +55,8 @@ public abstract class CropsPlusPlusRecipes extends BaseGTRecipeLoader {
     private static void addBerryToSugarRecipes() {
         GTModHandler.addShapelessCraftingRecipe(
             new ItemStack(Items.sugar, 4, 0),
-            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED,
+            GTModHandler.RecipeBits.NOT_REMOVABLE | GTModHandler.RecipeBits.BUFFERED
+                | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
             new Object[] { ToolDictNames.craftingToolMortar, CropsNHItemList.sugarBeet.get(1) });
     }
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
PR based on the log from https://github.com/GTNewHorizons/GT5-Unofficial/pull/7772. Basically all those recipes were looking to remove existing recipes before adding the craft, except the attempt for removal shown in log that it was useless, so we skip it to reduce lookups.

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
