### PR TITLE
remove unused bonsai code

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/crops/abstracts/CropBonsai.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/crops/abstracts/CropBonsai.java
@@ -29,8 +29,6 @@ public class CropBonsai extends NHCropCard {
         // drops
         ItemStack logDrop = log.copy();
         logDrop.stackSize = logCount;
-        ItemStack sapplingDrop = sapling.copy();
-        sapplingDrop.stackSize = 2;
         this.addDrop(sapling, 30_00);
         this.addDrop(logDrop, 60_00);
         // alt seed


### PR DESCRIPTION
## Summary
A follow-up to https://github.com/GTNewHorizons/CropsNH/pull/246. The bonsai was never supposed to set the saplings' drop count to 2. To be honest, I have no clue why that code was there; it's probably some relic of past debugging.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
  - No AI Used
- ❌  This PR requires another PR in order to merge
