### PR TITLE
Make Industral Farm change its mode via screwdriver

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
@@ -861,7 +861,8 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
     }
 
     @Override
-    public void onScrewdriverRightClick(ForgeDirection side, EntityPlayer aPlayer, float aX, float aY, float aZ, ItemStack aTool) {
+    public void onScrewdriverRightClick(ForgeDirection side, EntityPlayer aPlayer, float aX, float aY, float aZ,
+        ItemStack aTool) {
         this.setMachineMode(this.nextMachineMode());
         GTUtility.sendChatTrans(aPlayer, Reference.MOD_ID + "_chat.industrialFarm.mode.set", this.getMachineModeName());
     }

--- a/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/tileentity/multi/MTEIndustrialFarm.java
@@ -37,6 +37,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -857,6 +858,12 @@ public class MTEIndustrialFarm extends MTEExtendedPowerMultiBlockBase<MTEIndustr
                 .translateToLocal(Reference.MOD_ID + "_tooltip.industrialFarm.mode.output");
             default -> StatCollector.translateToLocal(Reference.MOD_ID + "_tooltip.industrialFarm.mode.input");
         };
+    }
+
+    @Override
+    public void onScrewdriverRightClick(ForgeDirection side, EntityPlayer aPlayer, float aX, float aY, float aZ, ItemStack aTool) {
+        this.setMachineMode(this.nextMachineMode());
+        GTUtility.sendChatTrans(aPlayer, Reference.MOD_ID + "_chat.industrialFarm.mode.set", this.getMachineModeName());
     }
 
     // endregion machine mode

--- a/src/main/resources/assets/cropsnh/lang/en_US.lang
+++ b/src/main/resources/assets/cropsnh/lang/en_US.lang
@@ -900,3 +900,6 @@ cropsnh_mutationPool.wheat=Wheat
 cropsnh_mutationPool.white=White
 cropsnh_mutationPool.wood=Wood
 cropsnh_mutationPool.yellow=Yellow
+
+# Chat Messages
+cropsnh_chat.industrialFarm.mode.set=Changed mode to %1$s


### PR DESCRIPTION
## Summary
This PR makes the Industrial Farm change its machine mode when right-clicked with a screwdriver, instead of toggling recipe locking, which I'm pretty sure is useless.


Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26477


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
