### PR TITLE
Track tired recipe component changes from core mod

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,39 +2,39 @@
 
 dependencies {
     // compile and runtime required dependencies
-    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.54.75:dev")
-    api("com.github.GTNewHorizons:GTNHLib:0.11.36:dev")
+    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.54.111:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.11.43:dev")
     shadowImplementation('com.github.makamys:MCLib:0.3.7.8') {
         exclude group: "codechicken"
     }
 
     // compile required dependencies
-    devOnlyNonPublishable("com.github.GTNewHorizons:TinkersConstruct:1.14.96-GTNH:dev") { transitive = false }
-    devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.118-GTNH:dev") { transitive = false }
-    devOnlyNonPublishable("com.github.GTNewHorizons:waila:1.19.31:dev") { transitive = false }
-    devOnlyNonPublishable("com.github.GTNewHorizons:ForestryMC:4.11.32:dev") { transitive = false }
+    devOnlyNonPublishable("com.github.GTNewHorizons:TinkersConstruct:1.14.103-GTNH:dev") { transitive = false }
+    devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.127-GTNH:dev") { transitive = false }
+    devOnlyNonPublishable("com.github.GTNewHorizons:waila:1.19.34:dev") { transitive = false }
+    devOnlyNonPublishable("com.github.GTNewHorizons:ForestryMC:4.11.37:dev") { transitive = false }
     devOnlyNonPublishable("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
-    devOnlyNonPublishable('com.github.GTNewHorizons:Backhand:1.8.13:dev') { transitive = false }
-    devOnlyNonPublishable('com.github.GTNewHorizons:FindIt:1.4.4:dev') { transitive = false }
+    devOnlyNonPublishable('com.github.GTNewHorizons:Backhand:1.8.14:dev') { transitive = false }
+    devOnlyNonPublishable('com.github.GTNewHorizons:FindIt:1.4.6:dev') { transitive = false }
 
     // // optional runtime dependencies, you'll want to copy over the full pack configs to your dev env or else it will crash.
     // // debugging tools
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:NewHorizonsCoreMod:2.9.29:dev")
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:ServerUtilities:2.4.6:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:NewHorizonsCoreMod:2.9.51:dev")
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:ServerUtilities:2.4.7:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:worldedit-gtnh:v0.0.9:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:WAILAPlugins:0.7.2:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:EnderCore:0.5.14:dev") { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.118-GTNH:dev") { transitive = false }
-    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:Opis:1.4.9-mapless:dev') { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:GTNHLib:0.11.36:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.127-GTNH:dev") { transitive = false }
+    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:Opis:1.4.12-mapless:dev') { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:GTNHLib:0.11.43:dev") { transitive = false }
     // // QOL/creature comforts
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-999-GTNH:dev") { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.5.100-gtnh:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.5.105-gtnh:dev") { transitive = false }
     // var tasks = project.gradle.startParameter.taskNames
     // if (tasks.contains("runClient17") || tasks.contains("runClient21") || tasks.contains("runClient25")) {
-    //     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Angelica:2.1.60:dev") { transitive = false }
+    //     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Angelica:2.2.8:dev") { transitive = false }
     // }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Hodgepodge:2.7.180:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Hodgepodge:2.7.191:dev") { transitive = false }
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:CoreTweaks:0.3.4.7-GTNH:dev') { transitive = false }
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:StorageDrawers:2.2.28-GTNH:dev') { transitive = false }
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:MouseTweaks:2.5.2-GTNH:dev') { transitive = false }
@@ -42,42 +42,42 @@ dependencies {
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:StructureLib:1.4.42:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:BlockRenderer6343:1.4.21:dev") { transitive = false }
     // // to check what counts as food
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:AppleCore:3.3.11:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:AppleCore:3.3.12:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:SpiceOfLife:2.2.10-carrot:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Nutrition:1.0.1:dev") { transitive = false }
     // // bee comparisons
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:BeeBetterAtBees-GTNH:0.4.7-GTNH:dev") { transitive = false }
-    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:Binnie:2.6.39:dev') { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:neiaddons:1.18.4:dev") { transitive = false }
+    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:Binnie:2.6.47:dev') { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:neiaddons:1.18.5:dev") { transitive = false }
     // // for mod specific crops
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Natura:2.8.23:dev") { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:twilightforest:2.7.38:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Natura:2.8.24:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:twilightforest:2.7.39:dev") { transitive = false }
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:ThaumicBases:1.9.19:dev") { transitive = false }
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:DummyCore:1.21.0:dev') { transitive = false }
     // runtimeOnlyNonPublishable("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
     // runtimeOnlyNonPublishable(deobfCurse('witchery-69673:2234410')) { transitive = false }
     // runtimeOnlyNonPublishable(rfg.deobf("curse.maven:biomes-o-plenty-220318:2499612")) { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Botania:1.13.32-GTNH:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Botania:1.13.34-GTNH:dev") { transitive = false }
     // runtimeOnlyNonPublishable("ganymedes01.etfuturum:Et-Futurum-Requiem:2.6.12-GTNH") { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:harvestcraft:1.3.13-GTNH:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:harvestcraft:1.3.14-GTNH:dev") { transitive = false }
     // // testing recipes
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Tainted-Magic:7.7.8-GTNH:dev") { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:WitcheryExtras:1.4.16:dev") { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:WitchingGadgets:1.8.48-GTNH:dev") { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:ThaumicTinkerer:2.12.29:dev") { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Galaxy-Space-GTNH:1.1.139-GTNH:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:WitcheryExtras:1.4.17:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:WitchingGadgets:1.8.50-GTNH:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:ThaumicTinkerer:2.12.30:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Galaxy-Space-GTNH:1.1.142-GTNH:dev") { transitive = false }
     // // required in order to have pam
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Chisel:2.17.31-GTNH:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Chisel:2.17.32-GTNH:dev") { transitive = false }
     // // mod specific crops and soils
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Galacticraft:3.4.32-GTNH:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Galacticraft:3.4.33-GTNH:dev") { transitive = false }
     // // soil debugging
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Random-Things:2.7.8:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Random-Things:2.7.9:dev") { transitive = false }
     // runtimeOnlyNonPublishable(rfg.deobf("curse.maven:ztones-224369:2223720")) { transitive = false }
-    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:MagicBees:2.10.10-GTNH:dev") { transitive = false }
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:MagicBees:2.10.12-GTNH:dev") { transitive = false }
     // // required in order for ztones to load right due to GT5u
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:BuildCraft:7.1.63:dev") { transitive = false }
     // // skull underblock requirement
-    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:EnderIO:2.10.36:dev') { transitive = false }
+    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:EnderIO:2.10.40:dev') { transitive = false }
     // // watering can interactions
     // runtimeOnlyNonPublishable(rfg.deobf("curse.maven:extra-utilities-225561:2264383")) { transitive = false }
 }
@@ -87,7 +87,7 @@ project.getConfigurations()
         final DependencySubstitutions ds = c.getResolutionStrategy()
             .getDependencySubstitution();
         ds.substitute(ds.module("com.github.GTNewHorizons:Baubles"))
-            .using(ds.module("com.github.GTNewHorizons:Baubles-Expanded:2.2.21-GTNH"))
+            .using(ds.module("com.github.GTNewHorizons:Baubles-Expanded:2.2.22-GTNH"))
             .withClassifier("dev")
             .because("Baubles-Expanded replaces Baubles");
     });

--- a/src/main/java/com/gtnewhorizon/cropsnh/api/CropsNHItemList.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/api/CropsNHItemList.java
@@ -1,5 +1,6 @@
 package com.gtnewhorizon.cropsnh.api;
 
+import static gregtech.GTLoggers.GT_FML_LOGGER;
 import static gregtech.api.enums.GTValues.NI;
 import static gregtech.api.util.GTRecipeBuilder.WILDCARD;
 
@@ -15,7 +16,6 @@ import com.gtnewhorizon.cropsnh.utility.CropsNHUtils;
 
 import gregtech.GTMod;
 import gregtech.api.interfaces.IItemContainer;
-import gregtech.api.util.GTLog;
 import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTUtility;
@@ -335,7 +335,7 @@ public enum CropsNHItemList implements IItemContainer {
     @Override
     public boolean isStackEqual(Object stack, boolean wildcard, boolean ignoreNBT) {
         if (this.deprecated && !this.warned) {
-            new Exception(this + " is now deprecated").printStackTrace(GTLog.err);
+            GT_FML_LOGGER.error(new Exception(this + " is now deprecated"));
             // warn only once
             this.warned = true;
         }
@@ -347,8 +347,8 @@ public enum CropsNHItemList implements IItemContainer {
     public ItemStack get(long amount, Object... replacements) {
         sanityCheck();
         if (GTUtility.isStackInvalid(this.stack)) {
-            GTLog.out.println("Object in the ItemList is null at:");
-            new NullPointerException().printStackTrace(GTLog.out);
+            GT_FML_LOGGER.debug("Object in the ItemList is null at:");
+            GT_FML_LOGGER.debug(new NullPointerException());
             return GTUtility.copyAmount(amount, replacements);
         }
         return CropsNHUtils.copyStackWithSize(this.stack, (int) amount);
@@ -452,9 +452,9 @@ public enum CropsNHItemList implements IItemContainer {
 
     private void sanityCheck() {
         if (this.hasNotBeenSet)
-            throw new IllegalAccessError("The Enum '" + name() + "' has not been set to an Item at this time!");
+            throw new IllegalAccessError("The Enum '" + this.name() + "' has not been set to an Item at this time!");
         if (this.deprecated && !this.warned) {
-            new Exception(this + " is now deprecated").printStackTrace(GTLog.err);
+            GT_FML_LOGGER.error(new Exception(this + " is now deprecated"));
             // warn only once
             this.warned = true;
         }

--- a/src/main/java/com/gtnewhorizon/cropsnh/loaders/GTRecipeLoader.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/loaders/GTRecipeLoader.java
@@ -801,7 +801,7 @@ public abstract class GTRecipeLoader extends BaseGTRecipeLoader {
             case VoltageIndex.UEV -> OrePrefixes.cableGt01.get(Materials.Draconium);
             case VoltageIndex.UIV -> OrePrefixes.cableGt01.get(Materials.NetherStar);
             case VoltageIndex.UMV -> OrePrefixes.cableGt01.get(Materials.Quantium);
-            case VoltageIndex.UXV -> OrePrefixes.wireGt01.get(Materials.SpaceTime);
+            case VoltageIndex.UXV -> OrePrefixes.cableGt01.get(Materials.BlackPlutonium);
             default -> MTEBasicMachineWithRecipe.X.WIRE;
         };
     }
@@ -822,10 +822,10 @@ public abstract class GTRecipeLoader extends BaseGTRecipeLoader {
             case VoltageIndex.ZPM -> OrePrefixes.plate.get(Materials.Iridium);
             case VoltageIndex.UV -> OrePrefixes.plate.get(Materials.Osmium);
             case VoltageIndex.UHV -> OrePrefixes.plate.get(Materials.Neutronium);
-            case VoltageIndex.UEV -> OrePrefixes.plate.get(Materials.Bedrockium);
-            case VoltageIndex.UIV -> OrePrefixes.plate.get(Materials.CosmicNeutronium);
-            case VoltageIndex.UMV -> OrePrefixes.plate.get(Materials.TranscendentMetal);
-            case VoltageIndex.UXV -> OrePrefixes.plate.get(Materials.SpaceTime);
+            case VoltageIndex.UEV -> OrePrefixes.plate.get(Materials.Infinity);
+            case VoltageIndex.UIV -> OrePrefixes.plate.get(Materials.TranscendentMetal);
+            case VoltageIndex.UMV -> OrePrefixes.plate.get(Materials.SpaceTime);
+            case VoltageIndex.UXV -> OrePrefixes.plate.get(Materials.MHDCSM);
             default -> MTEBasicMachineWithRecipe.X.PLATE;
         };
     }


### PR DESCRIPTION
## Summary
Tracks recent recipe changes regarding tired crafting components from the core mod.

## Screenshots

### Cable Materials
spacetime wire -> black plutonium cable:

<img width="1036" height="433" alt="image" src="https://github.com/user-attachments/assets/9235bb0c-661a-4e41-bab9-eae52e2e7876" />

### Plate Materials

uev: bedrockium -> infinity
<img width="450" height="222" alt="image" src="https://github.com/user-attachments/assets/34abd5c5-c32f-40ee-afd0-6721783392a3" />

uiv: cosmic neutronium -> transcendent metal
<img width="387" height="204" alt="image" src="https://github.com/user-attachments/assets/65a0623b-d189-4b67-ab6c-d0feb74c53d2" />

umv: transcendent metal -> space time
<img width="518" height="210" alt="image" src="https://github.com/user-attachments/assets/2db68eb0-a2a0-4453-b7b4-e0a5d5bd63cf" />

uxv: space time -> (currently unused)

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
  - No AI Used
- ❌ This PR requires another PR in order to merge
