### PR TITLE
Fix item stack map counts being lost on NBT load

### DIFF
--- a/src/main/java/com/gtnewhorizon/cropsnh/handler/migrations/IC2Migrations.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/handler/migrations/IC2Migrations.java
@@ -61,18 +61,18 @@ public class IC2Migrations {
                             Constants.MIN_SEED_STAT,
                             Math.min(
                                 Constants.MAX_SEED_STAT,
-                                NBTHelper.getIntgegerNumber(oldNBT, "statGrowth", Constants.MIN_SEED_STAT))),
+                                NBTHelper.getIntegerNumber(oldNBT, "statGrowth", Constants.MIN_SEED_STAT))),
                         (byte) Math.max(
                             Constants.MIN_SEED_STAT,
                             Math.min(
                                 Constants.MAX_SEED_STAT,
-                                NBTHelper.getIntgegerNumber(oldNBT, "statGain", Constants.MIN_SEED_STAT))),
+                                NBTHelper.getIntegerNumber(oldNBT, "statGain", Constants.MIN_SEED_STAT))),
                         (byte) Math.max(
                             Constants.MIN_SEED_STAT,
                             Math.min(
                                 Constants.MAX_SEED_STAT,
-                                NBTHelper.getIntgegerNumber(oldNBT, "statResistance", Constants.MIN_SEED_STAT))),
-                        NBTHelper.getIntgegerNumber(oldNBT, "scanLevel", 0) >= 1);
+                                NBTHelper.getIntegerNumber(oldNBT, "statResistance", Constants.MIN_SEED_STAT))),
+                        NBTHelper.getIntegerNumber(oldNBT, "scanLevel", 0) >= 1);
                     IAdditionalCropData extra = null;
                     // check if the crop can grow on the current farmland.
                     if (ConfigurationHandler.alwaysMigrateUsingMigrationCrop) {
@@ -108,18 +108,18 @@ public class IC2Migrations {
                     Constants.MIN_SEED_STAT,
                     Math.min(
                         Constants.MAX_SEED_STAT,
-                        NBTHelper.getIntgegerNumber(oldTag, "growth", Constants.MIN_SEED_STAT))),
+                        NBTHelper.getIntegerNumber(oldTag, "growth", Constants.MIN_SEED_STAT))),
                 (byte) Math.max(
                     Constants.MIN_SEED_STAT,
                     Math.min(
                         Constants.MAX_SEED_STAT,
-                        NBTHelper.getIntgegerNumber(oldTag, "gain", Constants.MIN_SEED_STAT))),
+                        NBTHelper.getIntegerNumber(oldTag, "gain", Constants.MIN_SEED_STAT))),
                 (byte) Math.max(
                     Constants.MIN_SEED_STAT,
                     Math.min(
                         Constants.MAX_SEED_STAT,
-                        NBTHelper.getIntgegerNumber(oldTag, "resistance", Constants.MIN_SEED_STAT))),
-                NBTHelper.getIntgegerNumber(oldTag, "scan", 0) >= 1);
+                        NBTHelper.getIntegerNumber(oldTag, "resistance", Constants.MIN_SEED_STAT))),
+                NBTHelper.getIntegerNumber(oldTag, "scan", 0) >= 1);
             // update the stack
             stack.setShort("id", (short) Item.getIdFromItem(CropsNHItems.genericSeed));
             stack.setShort("Damage", (short) 0);

--- a/src/main/java/com/gtnewhorizon/cropsnh/utility/NBTHelper.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/utility/NBTHelper.java
@@ -84,7 +84,7 @@ public abstract class NBTHelper {
         for (Map.Entry<ItemStack, Integer> entry : map.entrySet()) {
             NBTTagCompound entryNBT = new NBTTagCompound();
             entryNBT.setTag(NBT_ITEM_STACK_MAP_KEY, writeItemStackToNBT(entry.getKey()));
-            entryNBT.setDouble(NBT_ITEM_STACK_MAP_VALUE, entry.getValue());
+            entryNBT.setInteger(NBT_ITEM_STACK_MAP_VALUE, entry.getValue());
             nbt.appendTag(entryNBT);
         }
         return nbt;
@@ -97,7 +97,7 @@ public abstract class NBTHelper {
             if (entry.hasNoTags()) continue;
             ItemStack stack = ItemStack.loadItemStackFromNBT(entry.getCompoundTag(NBT_ITEM_STACK_MAP_KEY));
             if (stack == null) continue;
-            int value = getInteger(entry, NBT_ITEM_STACK_MAP_VALUE, 1);
+            int value = (int) getFloatingNumber(entry, NBT_ITEM_STACK_MAP_VALUE, 1);
             map.merge(stack, value, merger);
         }
     }

--- a/src/main/java/com/gtnewhorizon/cropsnh/utility/NBTHelper.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/utility/NBTHelper.java
@@ -32,20 +32,12 @@ public abstract class NBTHelper {
      * @param def The default value.
      * @return the value or default if it wasn't found.
      */
-    public static long getIntgegerNumber(NBTTagCompound tag, String key, long def) {
+    public static long getIntegerNumber(NBTTagCompound tag, String key, long def) {
         if (tag == null) return def;
-        switch (tag.func_150299_b(key)) {
-            case Constants.NBT.TAG_BYTE:
-                return tag.getByte(key);
-            case Constants.NBT.TAG_SHORT:
-                return tag.getShort(key);
-            case Constants.NBT.TAG_INT:
-                return tag.getInteger(key);
-            case Constants.NBT.TAG_LONG:
-                return tag.getLong(key);
-            default:
-                return def;
+        if (tag.getTag(key) instanceof NBTBase.NBTPrimitive primitive) {
+            return primitive.func_150291_c();
         }
+        return def;
     }
 
     /**
@@ -58,22 +50,10 @@ public abstract class NBTHelper {
      */
     public static double getFloatingNumber(NBTTagCompound tag, String key, double def) {
         if (tag == null) return def;
-        switch (tag.func_150299_b(key)) {
-            case Constants.NBT.TAG_BYTE:
-                return tag.getByte(key);
-            case Constants.NBT.TAG_SHORT:
-                return tag.getShort(key);
-            case Constants.NBT.TAG_INT:
-                return tag.getInteger(key);
-            case Constants.NBT.TAG_LONG:
-                return tag.getLong(key);
-            case Constants.NBT.TAG_FLOAT:
-                return tag.getFloat(key);
-            case Constants.NBT.TAG_DOUBLE:
-                return tag.getDouble(key);
-            default:
-                return def;
+        if (tag.getTag(key) instanceof NBTBase.NBTPrimitive primitive) {
+            return primitive.func_150286_g();
         }
+        return def;
     }
 
     private static final String NBT_ITEM_STACK_MAP_KEY = "key";
@@ -97,7 +77,7 @@ public abstract class NBTHelper {
             if (entry.hasNoTags()) continue;
             ItemStack stack = ItemStack.loadItemStackFromNBT(entry.getCompoundTag(NBT_ITEM_STACK_MAP_KEY));
             if (stack == null) continue;
-            int value = (int) getFloatingNumber(entry, NBT_ITEM_STACK_MAP_VALUE, 1);
+            int value = getIntegerNumber(entry, NBT_ITEM_STACK_MAP_VALUE, 1);
             map.merge(stack, value, merger);
         }
     }

--- a/src/main/java/com/gtnewhorizon/cropsnh/utility/NBTHelper.java
+++ b/src/main/java/com/gtnewhorizon/cropsnh/utility/NBTHelper.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.function.BiFunction;
 
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraftforge.common.util.Constants;
@@ -77,7 +78,7 @@ public abstract class NBTHelper {
             if (entry.hasNoTags()) continue;
             ItemStack stack = ItemStack.loadItemStackFromNBT(entry.getCompoundTag(NBT_ITEM_STACK_MAP_KEY));
             if (stack == null) continue;
-            int value = getIntegerNumber(entry, NBT_ITEM_STACK_MAP_VALUE, 1);
+            int value = (int) NBTHelper.getIntegerNumber(entry, NBT_ITEM_STACK_MAP_VALUE, 1);
             map.merge(stack, value, merger);
         }
     }


### PR DESCRIPTION
## Summary
In NBTHelper.java, saveItemStackMap wrote values as doubles and loadItemStackMap loaded them as integers. I changed it to save it as an integer and load it as a float converted into an integer for backwards compatibility with previous saving method.

Loading a double as an integer would default to 1 and lose data, so this should fix it.

I didn’t test this but I’m fairly sure it works just fine, since it’s just a different way to save and load the same things.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
